### PR TITLE
docs(repo): refresh repository contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,33 @@
 
 Public company website for Gother Labs.
 
-This repository hosts the static website that will be published with GitHub Pages and later connected to `www.gotherlabs.com`.
+## Overview
+
+This repository contains the production static site served through GitHub Pages for `www.gotherlabs.com`.
+
+- No build step or framework is used in this repository.
+- The custom domain is configured through `CNAME`.
+- `.nojekyll` keeps GitHub Pages serving the site as a plain static tree.
+
+## Repository shape
+
+- Root: publishable site files and deployment metadata such as `CNAME`, `robots.txt`, and `sitemap.xml`
+- `assets/`: shared static assets used by the site
+- `company/`, `contact/`, `careers/`, `evolther/`: section routes
+- `tools/`: internal support helpers that should not live in the repository root
+
+## Local preview
+
+Serve the repository root with a simple static server:
+
+```bash
+python3 -m http.server 4173
+```
+
+Then open `http://127.0.0.1:4173/`.
+
+## Maintenance rules
+
+- Keep tracked assets only when they are used by the site or by a documented helper workflow.
+- Remove deprecated public routes instead of leaving ambiguous stubs behind.
+- Keep internal or experimental helpers under `tools/`, not in the repository root.


### PR DESCRIPTION
## Why

The repository README no longer matched the live deployment state or the actual structure of `main`. That made the repo a weaker source of truth than it should be.

Closes #16.

## What changed

- updated `README.md` to reflect the active `www.gotherlabs.com` GitHub Pages setup
- documented the current repository shape and the purpose of `tools/`
- documented the local static preview command
- added a short maintenance policy for dead assets, deprecated routes, and root-level hygiene

## Why this approach

This keeps the documentation operational and concise. The goal is not to create a contributor manual, only to restore a trustworthy repository contract that matches the current site and recent cleanup work.

## How to review

- confirm the README now describes the live custom-domain setup correctly
- confirm the documented top-level structure matches current `main`
- confirm the maintenance rules are short and actionable rather than process-heavy

## Validation

- `git diff --check`
- local static preview:
  - `/` -> `200`
  - `/company/` -> `200`
  - `/contact/` -> `200`
  - `/404.html` -> `200`
  - `/tools/og-image.html` -> `200`
- verified the README preview command uses the repository root as served content

## Testing

- no build step or runtime application test suite applies here beyond static route verification
