### PR TITLE
Remove redundant home navigation logo

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,18 +27,6 @@
     <div class="page-shell site-shell">
       <header class="site-header">
         <nav class="site-nav" aria-label="Primary">
-          <a class="brand nav-brand" href="./" aria-label="Göther Labs home">
-            <svg
-              class="brand-image brand-mark site-brand-mark"
-              viewBox="0 0 64 64"
-              role="img"
-              aria-hidden="true"
-            >
-              <circle class="brand-mark-body" cx="32" cy="18" r="4.7" />
-              <circle class="brand-mark-body" cx="20" cy="38" r="4.7" />
-              <circle class="brand-mark-body" cx="44" cy="38" r="4.7" />
-            </svg>
-          </a>
           <a href="./company/">Company</a>
           <a href="./contact/">Contact</a>
         </nav>


### PR DESCRIPTION
## Why
The home page header included the Göther mark as a link back to the same page. On the home page this is redundant and competes visually with the primary Göther Labs wordmark in the hero.

Closes #22

## What changed
- Removed the header logo link from the home page navigation.
- Left internal page navigation unchanged so the logo still returns users to the home page from secondary pages.

## Why this approach
The adjustment is scoped to `index.html` because only the home page has the redundant self-link. Internal pages keep the existing affordance for returning home.

## How to review
- Open the home page and verify the header only shows Company and Contact.
- Open Company or Contact and verify the logo link remains available in the header.

## Validation
- `git diff --check`
- `curl -s http://127.0.0.1:4173/ | sed -n "27,34p"`
- `curl -s http://127.0.0.1:4173/company/ | sed -n "29,36p"`

## Testing
No runtime code changed. This is a static HTML navigation change validated against the local static server.