### PR TITLE
Point website sync to results repository

### DIFF
--- a/results/quadrature-rule-optimization/index.html
+++ b/results/quadrature-rule-optimization/index.html
@@ -852,7 +852,7 @@ p=1.7.
 <p>The public bundle includes the evaluation contract, accepted candidate, curated evolution trace, metrics, provenance, residual readout, and replay surface. The article uses those artifacts as the source for the figures, tables, and accepted implementation.</p>
 <p>An animated replay of the same public trace is available at <a href="./run/">the run page</a>. It is a presentation layer over the same artifacts, not a separate result, and excludes non-public proposal context.</p>
 <p>Replaying the result should use the same analytic integrand suite, the same objective definition, the same run baseline, and the same lower-is-better direction. Changing any of those items creates a new evaluation, not a replay of this result.</p>
-<p>The source bundle is available in <a href="https://github.com/Gother-Labs/gother-labs-open-results/tree/main/results/quadrature-rule-optimization" target="_blank" rel="noreferrer">Göther Labs results repository</a>.</p>
+<p>The source bundle is available in <a href="https://github.com/Gother-Labs/gother-labs-results/tree/main/results/quadrature-rule-optimization" target="_blank" rel="noreferrer">Göther Labs results repository</a>.</p>
           </article>
         </section>
       </main>

--- a/tools/sync-open-results.mjs
+++ b/tools/sync-open-results.mjs
@@ -5,7 +5,7 @@ import { fileURLToPath } from "node:url";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const SITE_ROOT = path.resolve(__dirname, "..");
-const RESULTS_ROOT = path.resolve(SITE_ROOT, "..", "gother-labs-open-results");
+const RESULTS_ROOT = path.resolve(SITE_ROOT, "..", "gother-labs-results");
 const CATALOG_PATH = path.join(RESULTS_ROOT, "catalog.json");
 const OUT_ROOT = path.join(SITE_ROOT, "results");
 


### PR DESCRIPTION
## Why

The source repository for published result bundles was renamed to `gother-labs-results`. The website sync tool and generated source links should use that repository directly instead of relying on GitHub redirects from the old name.

## What changed

- Updated `tools/sync-open-results.mjs` to read from `../gother-labs-results`.
- Regenerated the quadrature result page so its GitHub source link points to `Gother-Labs/gother-labs-results`.

## Why this approach

The website continues to treat the result repository as the source of truth, but the local path and public GitHub links now match the renamed repository.

## Validation

- `node tools/sync-open-results.mjs`
- `node --check tools/sync-open-results.mjs`
- `git diff --check`
- Local smoke check: `/results/` returned `200`.

## Testing

No UI layout or result content changed beyond repository naming/reference updates.
