### PR TITLE
Publish RCPSP source bundle link

### DIFF
--- a/results/rcpsp-psplib-j30/index.html
+++ b/results/rcpsp-psplib-j30/index.html
@@ -1062,6 +1062,7 @@ score = mean(g_k) + 0.35 \cdot p95(g_k) + feasibility\_penalty.
 <h3>6. Reproducibility</h3>
 <p>The bundle includes the accepted candidate, evaluation contract, curated evolution chain, metrics, provenance, replay confirmation, and public figures. A curated animated replay of the same public trace is available at <a href="./run/">the run page</a>. It is a presentation layer over the same artifacts, not a separate result, and excludes prompts, raw logs, telemetry, and non-public proposal context.</p>
 <p>Replaying the result should use the same PSPLIB J30 portfolio, the same proven optimal makespans, the same score formula, and the same lower-is-better direction. Changing the instance set or objective creates a new evaluation, not a replay of this result.</p>
+<p>The source bundle is available in <a href="https://github.com/Gother-Labs/gother-labs-results/tree/main/results/rcpsp-psplib-j30" target="_blank" rel="noreferrer">Göther Labs results repository</a>.</p>
           </article>
         </section>
       </main>


### PR DESCRIPTION
## Why

The generated RCPSP result page should expose the same source bundle link as the source article.

## What changed

- Published the RCPSP reproducibility source-bundle link in `results/rcpsp-psplib-j30/index.html`.

## Validation

- Generated from `gother-labs-results` via `node tools/sync-open-results.mjs` before committing.

## Testing

Static HTML update only. No layout or result metrics changed.
