### PR TITLE
Clean results naming in website tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,15 @@ This repository contains the production static site served through GitHub Pages 
 
 - Root: publishable site files and deployment metadata such as `CNAME`, `robots.txt`, and `sitemap.xml`
 - `assets/`: shared static assets used by the site
-- `company/`, `contact/`, `careers/`, `evolther/`: section routes
+- `company/`, `contact/`, `results/`, `evolther/`: section routes
+- `careers/`: legacy redirect to `contact/`
 - `tools/`: internal support helpers that should not live in the repository root
+
+Published result pages are generated from the sibling `gother-labs-results` repository:
+
+```bash
+node tools/sync-results.mjs
+```
 
 ## Local preview
 

--- a/results/quadrature-rule-optimization/artifacts/accepted_candidate.py
+++ b/results/quadrature-rule-optimization/artifacts/accepted_candidate.py
@@ -1,4 +1,4 @@
-"""Accepted candidate exported for the Open Result bundle.
+"""Accepted candidate exported for the result bundle.
 
 This file contains only the accepted public quadrature rule. It omits
 non-public proposal context and operational run records.

--- a/tools/sync-results.mjs
+++ b/tools/sync-results.mjs
@@ -403,40 +403,6 @@ async function copyDirectoryIfExists(source, target) {
   await fs.cp(source, target, { recursive: true });
 }
 
-async function rewritePublishedResultRoutes(root) {
-  let entries;
-  try {
-    entries = await fs.readdir(root, { withFileTypes: true });
-  } catch {
-    return;
-  }
-
-  for (const entry of entries) {
-    const entryPath = path.join(root, entry.name);
-    if (entry.isDirectory()) {
-      await rewritePublishedResultRoutes(entryPath);
-      continue;
-    }
-
-    if (!/\.(html|css|js|xml)$/i.test(entry.name)) {
-      continue;
-    }
-
-    const original = await fs.readFile(entryPath, "utf8");
-    const updated = original
-      .replaceAll("/open-results/", "/results/")
-      .replaceAll("../../../open-results/", "../../../results/")
-      .replaceAll("../../open-results/", "../../results/")
-      .replaceAll("../open-results/", "../results/")
-      .replaceAll("open-results-card", "results-card")
-      .replaceAll(">Open Results<", ">Results<");
-
-    if (updated !== original) {
-      await fs.writeFile(entryPath, updated, "utf8");
-    }
-  }
-}
-
 function extractCandidateCode(code) {
   const match = code.match(/# EVOLVE_START:[^\n]*\n?([\s\S]*?)\n?# EVOLVE_END/);
   const candidateCode = match ? match[1] : code;
@@ -1945,7 +1911,6 @@ async function writeDetail(result) {
     await copyIfExists(resultRoot, outputRoot, file);
   }
   await copyDirectoryIfExists(path.join(resultRoot, "run"), path.join(outputRoot, "run"));
-  await rewritePublishedResultRoutes(path.join(outputRoot, "run"));
 
   const figures = plots
     .map(


### PR DESCRIPTION
## Summary\n- Rename the website sync helper to `tools/sync-results.mjs`\n- Remove legacy `/open-results/` route rewriting from copied run bundles\n- Update website README and regenerated published candidate wording\n\n## Validation\n- `node tools/sync-results.mjs`\n- `node --check tools/sync-results.mjs`\n- `node --check scripts.js`\n- `node --check results/quadrature-rule-optimization/run/surface.js`\n- `node --check results/rcpsp-psplib-j30/run/surface.js`\n- Parsed key HTML pages\n- Smoke-tested key local routes with Python urllib