### PR TITLE
Rename internal result classes

### DIFF
--- a/results/index.html
+++ b/results/index.html
@@ -41,9 +41,9 @@
         </section>
 
         <section class="results-index" aria-label="Results library">
-<article class="open-result-card open-result-card--quadrature">
-            <a class="open-result-link" href="./quadrature-rule-optimization/" aria-label="Read Quadrature rule optimization">
-              <svg class="open-result-card-visual" viewBox="0 0 560 360" aria-hidden="true" focusable="false">
+<article class="result-card result-card--quadrature">
+            <a class="result-link" href="./quadrature-rule-optimization/" aria-label="Read Quadrature rule optimization">
+              <svg class="result-card-visual" viewBox="0 0 560 360" aria-hidden="true" focusable="false">
                 <defs>
                   <clipPath id="quadrature-card-area">
                     <path d="M44 286 L44 230 C95 166 154 109 226 82 C310 50 409 72 516 148 L516 286 Z" />
@@ -52,7 +52,7 @@
                     <line x1="0" y1="0" x2="0" y2="18" />
                   </pattern>
                 </defs>
-                <g class="open-result-card-chart">
+                <g class="result-card-chart">
                   <line x1="44" y1="286" x2="516" y2="286" />
                   <line x1="44" y1="286" x2="44" y2="48" />
                   <line x1="44" y1="92" x2="516" y2="92" class="grid" />
@@ -73,12 +73,12 @@
                   </g>
                 </g>
               </svg>
-              <div class="open-result-meta">
+              <div class="result-meta">
                 <p class="eyebrow">01 Scientific Computing</p>
               </div>
               <h2>Quadrature rule optimization</h2>
               <p>A five-node integration rule is compared against a fixed baseline, with both the acceptance score and direct residual errors exposed.</p>
-              <div class="open-result-measure">
+              <div class="result-measure">
                 <span>Acceptance objective</span>
                 <strong>688.68 -&gt; 114.51</strong>
                 <span>Largest residual</span>
@@ -87,10 +87,10 @@
             </a>
           </article>
 
-<article class="open-result-card open-result-card--rcpsp">
-            <a class="open-result-link" href="./rcpsp-psplib-j30/" aria-label="Read PSPLIB J30 scheduling benchmark">
-              <svg class="open-result-card-visual open-result-card-visual--rcpsp" viewBox="0 0 560 360" aria-hidden="true" focusable="false">
-                <g class="open-result-card-rcpsp">
+<article class="result-card result-card--rcpsp">
+            <a class="result-link" href="./rcpsp-psplib-j30/" aria-label="Read PSPLIB J30 scheduling benchmark">
+              <svg class="result-card-visual result-card-visual--rcpsp" viewBox="0 0 560 360" aria-hidden="true" focusable="false">
+                <g class="result-card-rcpsp">
                   <g class="schedule">
                     <path class="lane" d="M52 92 H508 M52 128 H508 M52 164 H508 M52 200 H508 M52 236 H508" />
                     <path class="axis" d="M52 258 H508" />
@@ -144,12 +144,12 @@
                   </g>
                 </g>
               </svg>
-              <div class="open-result-meta">
+              <div class="result-meta">
                 <p class="eyebrow">02 Operational Planning</p>
               </div>
               <h2>PSPLIB J30 scheduling benchmark</h2>
               <p>A scheduling dispatch rule is evaluated against PSPLIB J30 optima, reducing the governed score while preserving feasibility.</p>
-              <div class="open-result-measure">
+              <div class="result-measure">
                 <span>Mean gap to optimum</span>
                 <strong>6.04%</strong>
                 <span>Real schedule cut</span>

--- a/results/quadrature-rule-optimization/artifacts/evolution.json
+++ b/results/quadrature-rule-optimization/artifacts/evolution.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": "open-result-evolution/v1",
+  "schema_version": "result-evolution/v1",
   "slug": "quadrature-rule-optimization",
   "steps": [
     {

--- a/results/quadrature-rule-optimization/index.html
+++ b/results/quadrature-rule-optimization/index.html
@@ -33,7 +33,7 @@
     <script defer src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js"></script>
 
   </head>
-  <body class="open-result-quadrature-page">
+  <body class="result-quadrature-page">
     <a class="skip-link" href="#site-main">Skip to content</a>
     <div class="page-shell site-shell">
       <header class="site-header">
@@ -48,13 +48,13 @@
       </header>
 
       <main class="site-main" id="site-main">
-        <section class="hero compact-hero page-hero open-result-detail-hero">
+        <section class="hero compact-hero page-hero result-detail-hero">
           <h1 class="page-title">Quadrature rule optimization</h1>
           <p class="intro results-hero-intro">A compact five-node rule for estimating one-dimensional integrals, improved against a fixed public test suite. The report separates the acceptance score from direct residual errors so the gain can be inspected, replayed, and challenged.</p>
         </section>
 
-        <section class="open-result-detail open-result-whitepaper-shell">
-          <article class="open-result-article open-result-whitepaper">
+        <section class="result-detail result-whitepaper-shell">
+          <article class="result-article result-whitepaper">
 <h3>Abstract</h3>
 <p>This note reports a compact five-node rule for estimating one-dimensional integrals on the unit interval. Relative to the fixed public baseline, the accepted rule reduces the frozen lower-is-better acceptance score by 83.37%. On the most improved public residual component, the direct numerical error falls from 0.3634 to 0.0010, a 99.72% reduction.</p>
 <p>The public claim is bounded to the stated one-dimensional analytic test contract. The acceptance score is the retention objective used by the run; the residual errors are the direct numerical readout. Both surfaces are shown so the candidate can be audited without presenting the rule as a universal integration method.</p>
@@ -66,8 +66,8 @@ I[g] = \int_{0}^{1} g(x)\,dx.
 \]</div>
   <span class="equation-number">(1)</span>
 </div>
-<figure class="open-result-primer-card open-result-paper-figure" id="fig-1">
-              <svg class="open-result-primer-svg open-result-paper-chart-svg" viewBox="0 0 560 306" role="img" aria-label="Conceptual exact integral for an arbitrary function g on the unit interval.">
+<figure class="result-primer-card result-paper-figure" id="fig-1">
+              <svg class="result-primer-svg result-paper-chart-svg" viewBox="0 0 560 306" role="img" aria-label="Conceptual exact integral for an arbitrary function g on the unit interval.">
                 <defs>
                   <clipPath id="conceptExactPlotClip">
                     <rect x="72" y="72" width="438" height="166" />
@@ -79,19 +79,19 @@ I[g] = \int_{0}^{1} g(x)\,dx.
                     <line x1="0" y1="0" x2="0" y2="12" />
                   </pattern>
                 </defs>
-                <text class="open-result-axis-label open-result-figure-title" x="72" y="34">Conceptual integral of an arbitrary g(x)</text>
-                <path class="open-result-primer-grid" d="M72 74 V238 H510" />
-                <path class="open-result-objective-grid" d="M72 98.0 H510" />
-                <text class="open-result-axis-tick open-result-y-tick" x="56" y="102">1</text>
-                <path class="open-result-axis-notch" d="M66 98 H72" />
-                <text class="open-result-axis-tick" x="72" y="260">0</text>
-                <text class="open-result-axis-tick" x="510" y="260">1</text>
-                <text class="open-result-axis-label open-result-x-axis-title" x="291" y="286">x</text>
-                <text class="open-result-axis-label open-result-objective-y-title" x="34" y="156" transform="rotate(-90 34 156)">g(x)</text>
+                <text class="result-axis-label result-figure-title" x="72" y="34">Conceptual integral of an arbitrary g(x)</text>
+                <path class="result-primer-grid" d="M72 74 V238 H510" />
+                <path class="result-objective-grid" d="M72 98.0 H510" />
+                <text class="result-axis-tick result-y-tick" x="56" y="102">1</text>
+                <path class="result-axis-notch" d="M66 98 H72" />
+                <text class="result-axis-tick" x="72" y="260">0</text>
+                <text class="result-axis-tick" x="510" y="260">1</text>
+                <text class="result-axis-label result-x-axis-title" x="291" y="286">x</text>
+                <text class="result-axis-label result-objective-y-title" x="34" y="156" transform="rotate(-90 34 156)">g(x)</text>
                 <g clip-path="url(#conceptExactPlotClip)">
-                  <path class="open-result-primer-area exact-integral-area" d="M72.0 238.0 L76.9 234.3 L81.8 230.5 L86.8 226.8 L91.7 223.0 L96.6 219.3 L101.5 215.6 L106.4 211.8 L111.4 208.2 L116.3 204.5 L121.2 200.9 L126.1 197.3 L131.1 193.7 L136.0 190.2 L140.9 186.7 L145.8 183.3 L150.7 179.9 L155.7 176.6 L160.6 173.4 L165.5 170.2 L170.4 167.1 L175.3 164.1 L180.3 161.2 L185.2 158.4 L190.1 155.6 L195.0 153.0 L200.0 150.4 L204.9 147.9 L209.8 145.6 L214.7 143.3 L219.6 141.2 L224.6 139.2 L229.5 137.3 L234.4 135.5 L239.3 133.8 L244.2 132.3 L249.2 130.9 L254.1 129.6 L259.0 128.4 L263.9 127.4 L268.9 126.5 L273.8 125.8 L278.7 125.2 L283.6 124.7 L288.5 124.4 L293.5 124.2 L298.4 124.2 L303.3 124.2 L308.2 124.5 L313.1 124.9 L318.1 125.4 L323.0 126.1 L327.9 126.9 L332.8 127.8 L337.8 128.9 L342.7 130.1 L347.6 131.5 L352.5 133.0 L357.4 134.6 L362.4 136.4 L367.3 138.3 L372.2 140.4 L377.1 142.5 L382.0 144.8 L387.0 147.3 L391.9 149.8 L396.8 152.5 L401.7 155.2 L406.7 158.1 L411.6 161.1 L416.5 164.2 L421.4 167.4 L426.3 170.7 L431.3 174.1 L436.2 177.6 L441.1 181.2 L446.0 184.9 L450.9 188.6 L455.9 192.4 L460.8 196.3 L465.7 200.3 L470.6 204.3 L475.6 208.4 L480.5 212.5 L485.4 216.7 L490.3 220.9 L495.2 225.1 L500.2 229.4 L505.1 233.7 L510.0 238.0 L510 238 L72 238 Z" />
-                  <rect class="open-result-integral-hatch" x="72" y="74" width="438" height="164" clip-path="url(#conceptExactIntegralClip)" />
-                  <path class="open-result-primer-curve" d="M72.0 238.0 L76.9 234.3 L81.8 230.5 L86.8 226.8 L91.7 223.0 L96.6 219.3 L101.5 215.6 L106.4 211.8 L111.4 208.2 L116.3 204.5 L121.2 200.9 L126.1 197.3 L131.1 193.7 L136.0 190.2 L140.9 186.7 L145.8 183.3 L150.7 179.9 L155.7 176.6 L160.6 173.4 L165.5 170.2 L170.4 167.1 L175.3 164.1 L180.3 161.2 L185.2 158.4 L190.1 155.6 L195.0 153.0 L200.0 150.4 L204.9 147.9 L209.8 145.6 L214.7 143.3 L219.6 141.2 L224.6 139.2 L229.5 137.3 L234.4 135.5 L239.3 133.8 L244.2 132.3 L249.2 130.9 L254.1 129.6 L259.0 128.4 L263.9 127.4 L268.9 126.5 L273.8 125.8 L278.7 125.2 L283.6 124.7 L288.5 124.4 L293.5 124.2 L298.4 124.2 L303.3 124.2 L308.2 124.5 L313.1 124.9 L318.1 125.4 L323.0 126.1 L327.9 126.9 L332.8 127.8 L337.8 128.9 L342.7 130.1 L347.6 131.5 L352.5 133.0 L357.4 134.6 L362.4 136.4 L367.3 138.3 L372.2 140.4 L377.1 142.5 L382.0 144.8 L387.0 147.3 L391.9 149.8 L396.8 152.5 L401.7 155.2 L406.7 158.1 L411.6 161.1 L416.5 164.2 L421.4 167.4 L426.3 170.7 L431.3 174.1 L436.2 177.6 L441.1 181.2 L446.0 184.9 L450.9 188.6 L455.9 192.4 L460.8 196.3 L465.7 200.3 L470.6 204.3 L475.6 208.4 L480.5 212.5 L485.4 216.7 L490.3 220.9 L495.2 225.1 L500.2 229.4 L505.1 233.7 L510.0 238.0" />
+                  <path class="result-primer-area exact-integral-area" d="M72.0 238.0 L76.9 234.3 L81.8 230.5 L86.8 226.8 L91.7 223.0 L96.6 219.3 L101.5 215.6 L106.4 211.8 L111.4 208.2 L116.3 204.5 L121.2 200.9 L126.1 197.3 L131.1 193.7 L136.0 190.2 L140.9 186.7 L145.8 183.3 L150.7 179.9 L155.7 176.6 L160.6 173.4 L165.5 170.2 L170.4 167.1 L175.3 164.1 L180.3 161.2 L185.2 158.4 L190.1 155.6 L195.0 153.0 L200.0 150.4 L204.9 147.9 L209.8 145.6 L214.7 143.3 L219.6 141.2 L224.6 139.2 L229.5 137.3 L234.4 135.5 L239.3 133.8 L244.2 132.3 L249.2 130.9 L254.1 129.6 L259.0 128.4 L263.9 127.4 L268.9 126.5 L273.8 125.8 L278.7 125.2 L283.6 124.7 L288.5 124.4 L293.5 124.2 L298.4 124.2 L303.3 124.2 L308.2 124.5 L313.1 124.9 L318.1 125.4 L323.0 126.1 L327.9 126.9 L332.8 127.8 L337.8 128.9 L342.7 130.1 L347.6 131.5 L352.5 133.0 L357.4 134.6 L362.4 136.4 L367.3 138.3 L372.2 140.4 L377.1 142.5 L382.0 144.8 L387.0 147.3 L391.9 149.8 L396.8 152.5 L401.7 155.2 L406.7 158.1 L411.6 161.1 L416.5 164.2 L421.4 167.4 L426.3 170.7 L431.3 174.1 L436.2 177.6 L441.1 181.2 L446.0 184.9 L450.9 188.6 L455.9 192.4 L460.8 196.3 L465.7 200.3 L470.6 204.3 L475.6 208.4 L480.5 212.5 L485.4 216.7 L490.3 220.9 L495.2 225.1 L500.2 229.4 L505.1 233.7 L510.0 238.0 L510 238 L72 238 Z" />
+                  <rect class="result-integral-hatch" x="72" y="74" width="438" height="164" clip-path="url(#conceptExactIntegralClip)" />
+                  <path class="result-primer-curve" d="M72.0 238.0 L76.9 234.3 L81.8 230.5 L86.8 226.8 L91.7 223.0 L96.6 219.3 L101.5 215.6 L106.4 211.8 L111.4 208.2 L116.3 204.5 L121.2 200.9 L126.1 197.3 L131.1 193.7 L136.0 190.2 L140.9 186.7 L145.8 183.3 L150.7 179.9 L155.7 176.6 L160.6 173.4 L165.5 170.2 L170.4 167.1 L175.3 164.1 L180.3 161.2 L185.2 158.4 L190.1 155.6 L195.0 153.0 L200.0 150.4 L204.9 147.9 L209.8 145.6 L214.7 143.3 L219.6 141.2 L224.6 139.2 L229.5 137.3 L234.4 135.5 L239.3 133.8 L244.2 132.3 L249.2 130.9 L254.1 129.6 L259.0 128.4 L263.9 127.4 L268.9 126.5 L273.8 125.8 L278.7 125.2 L283.6 124.7 L288.5 124.4 L293.5 124.2 L298.4 124.2 L303.3 124.2 L308.2 124.5 L313.1 124.9 L318.1 125.4 L323.0 126.1 L327.9 126.9 L332.8 127.8 L337.8 128.9 L342.7 130.1 L347.6 131.5 L352.5 133.0 L357.4 134.6 L362.4 136.4 L367.3 138.3 L372.2 140.4 L377.1 142.5 L382.0 144.8 L387.0 147.3 L391.9 149.8 L396.8 152.5 L401.7 155.2 L406.7 158.1 L411.6 161.1 L416.5 164.2 L421.4 167.4 L426.3 170.7 L431.3 174.1 L436.2 177.6 L441.1 181.2 L446.0 184.9 L450.9 188.6 L455.9 192.4 L460.8 196.3 L465.7 200.3 L470.6 204.3 L475.6 208.4 L480.5 212.5 L485.4 216.7 L490.3 220.9 L495.2 225.1 L500.2 229.4 L505.1 233.7 L510.0 238.0" />
                 </g>
               </svg>
               <figcaption>Figure 1. Conceptual setup for the exact integral. The shaded surface denotes \(I[g]\) for an arbitrary function \(g\), separate from the public integrand suite used by the evaluation contract.</figcaption>
@@ -107,8 +107,8 @@ x_i \in [0,1],
 \]</div>
   <span class="equation-number">(2)</span>
 </div>
-<figure class="open-result-primer-card open-result-paper-figure" id="fig-2">
-              <svg class="open-result-primer-svg open-result-paper-chart-svg" viewBox="0 0 560 306" role="img" aria-label="Conceptual quadrature rule showing weighted point evaluations of an arbitrary function.">
+<figure class="result-primer-card result-paper-figure" id="fig-2">
+              <svg class="result-primer-svg result-paper-chart-svg" viewBox="0 0 560 306" role="img" aria-label="Conceptual quadrature rule showing weighted point evaluations of an arbitrary function.">
                 <defs>
                   <clipPath id="conceptQuadraturePlotClip">
                     <rect x="72" y="72" width="438" height="166" />
@@ -117,71 +117,71 @@ x_i \in [0,1],
                     <line x1="0" y1="0" x2="0" y2="12" />
                   </pattern>
                 </defs>
-                <text class="open-result-axis-label open-result-figure-title" x="72" y="34">Weighted point evaluations</text>
-                <path class="open-result-primer-grid" d="M72 74 V238 H510" />
-                <path class="open-result-objective-grid" d="M72 98.0 H510" />
-                <text class="open-result-axis-tick open-result-y-tick" x="56" y="102">1</text>
-                <path class="open-result-axis-notch" d="M66 98 H72" />
-                <text class="open-result-axis-tick" x="72" y="260">0</text>
-                <text class="open-result-axis-tick" x="510" y="260">1</text>
-                <text class="open-result-axis-label open-result-x-axis-title" x="291" y="286">x</text>
-                <text class="open-result-axis-label open-result-objective-y-title" x="34" y="156" transform="rotate(-90 34 156)">g(x)</text>
+                <text class="result-axis-label result-figure-title" x="72" y="34">Weighted point evaluations</text>
+                <path class="result-primer-grid" d="M72 74 V238 H510" />
+                <path class="result-objective-grid" d="M72 98.0 H510" />
+                <text class="result-axis-tick result-y-tick" x="56" y="102">1</text>
+                <path class="result-axis-notch" d="M66 98 H72" />
+                <text class="result-axis-tick" x="72" y="260">0</text>
+                <text class="result-axis-tick" x="510" y="260">1</text>
+                <text class="result-axis-label result-x-axis-title" x="291" y="286">x</text>
+                <text class="result-axis-label result-objective-y-title" x="34" y="156" transform="rotate(-90 34 156)">g(x)</text>
                 <g clip-path="url(#conceptQuadraturePlotClip)">
-                  <g class="open-result-concept-samples">
-<g class="open-result-concept-sample ">
+                  <g class="result-concept-samples">
+<g class="result-concept-sample ">
               <rect x="72.0" y="214.7" width="61.3" height="23.3" />
               <line x1="102.7" y1="238" x2="102.7" y2="214.7" />
               <circle cx="102.7" cy="214.7" r="4.2" />
             </g>
-<g class="open-result-concept-sample ">
+<g class="result-concept-sample ">
               <rect x="133.3" y="161.8" width="92.0" height="76.2" />
               <line x1="179.3" y1="238" x2="179.3" y2="161.8" />
               <circle cx="179.3" cy="161.8" r="4.2" />
             </g>
-<g class="open-result-concept-sample is-accepted">
+<g class="result-concept-sample is-accepted">
               <rect x="225.3" y="124.3" width="131.4" height="113.7" />
               <line x1="291.0" y1="238" x2="291.0" y2="124.3" />
               <circle cx="291.0" cy="124.3" r="4.2" />
             </g>
-<g class="open-result-concept-sample ">
+<g class="result-concept-sample ">
               <rect x="356.7" y="155.8" width="92.0" height="82.2" />
               <line x1="402.7" y1="238" x2="402.7" y2="155.8" />
               <circle cx="402.7" cy="155.8" r="4.2" />
             </g>
-<g class="open-result-concept-sample ">
+<g class="result-concept-sample ">
               <rect x="448.7" y="211.5" width="61.3" height="26.5" />
               <line x1="479.3" y1="238" x2="479.3" y2="211.5" />
               <circle cx="479.3" cy="211.5" r="4.2" />
             </g>
                   </g>
-                  <g class="open-result-concept-samples open-result-concept-sample-hatches">
-<g class="open-result-concept-sample ">
+                  <g class="result-concept-samples result-concept-sample-hatches">
+<g class="result-concept-sample ">
               <rect x="72.0" y="214.7" width="61.3" height="23.3" />
               <line x1="102.7" y1="238" x2="102.7" y2="214.7" />
               <circle cx="102.7" cy="214.7" r="4.2" />
             </g>
-<g class="open-result-concept-sample ">
+<g class="result-concept-sample ">
               <rect x="133.3" y="161.8" width="92.0" height="76.2" />
               <line x1="179.3" y1="238" x2="179.3" y2="161.8" />
               <circle cx="179.3" cy="161.8" r="4.2" />
             </g>
-<g class="open-result-concept-sample is-accepted">
+<g class="result-concept-sample is-accepted">
               <rect x="225.3" y="124.3" width="131.4" height="113.7" />
               <line x1="291.0" y1="238" x2="291.0" y2="124.3" />
               <circle cx="291.0" cy="124.3" r="4.2" />
             </g>
-<g class="open-result-concept-sample ">
+<g class="result-concept-sample ">
               <rect x="356.7" y="155.8" width="92.0" height="82.2" />
               <line x1="402.7" y1="238" x2="402.7" y2="155.8" />
               <circle cx="402.7" cy="155.8" r="4.2" />
             </g>
-<g class="open-result-concept-sample ">
+<g class="result-concept-sample ">
               <rect x="448.7" y="211.5" width="61.3" height="26.5" />
               <line x1="479.3" y1="238" x2="479.3" y2="211.5" />
               <circle cx="479.3" cy="211.5" r="4.2" />
             </g>
                   </g>
-                  <path class="open-result-primer-curve muted-curve dashed-curve" d="M72.0 238.0 L76.9 234.3 L81.8 230.5 L86.8 226.8 L91.7 223.0 L96.6 219.3 L101.5 215.6 L106.4 211.8 L111.4 208.2 L116.3 204.5 L121.2 200.9 L126.1 197.3 L131.1 193.7 L136.0 190.2 L140.9 186.7 L145.8 183.3 L150.7 179.9 L155.7 176.6 L160.6 173.4 L165.5 170.2 L170.4 167.1 L175.3 164.1 L180.3 161.2 L185.2 158.4 L190.1 155.6 L195.0 153.0 L200.0 150.4 L204.9 147.9 L209.8 145.6 L214.7 143.3 L219.6 141.2 L224.6 139.2 L229.5 137.3 L234.4 135.5 L239.3 133.8 L244.2 132.3 L249.2 130.9 L254.1 129.6 L259.0 128.4 L263.9 127.4 L268.9 126.5 L273.8 125.8 L278.7 125.2 L283.6 124.7 L288.5 124.4 L293.5 124.2 L298.4 124.2 L303.3 124.2 L308.2 124.5 L313.1 124.9 L318.1 125.4 L323.0 126.1 L327.9 126.9 L332.8 127.8 L337.8 128.9 L342.7 130.1 L347.6 131.5 L352.5 133.0 L357.4 134.6 L362.4 136.4 L367.3 138.3 L372.2 140.4 L377.1 142.5 L382.0 144.8 L387.0 147.3 L391.9 149.8 L396.8 152.5 L401.7 155.2 L406.7 158.1 L411.6 161.1 L416.5 164.2 L421.4 167.4 L426.3 170.7 L431.3 174.1 L436.2 177.6 L441.1 181.2 L446.0 184.9 L450.9 188.6 L455.9 192.4 L460.8 196.3 L465.7 200.3 L470.6 204.3 L475.6 208.4 L480.5 212.5 L485.4 216.7 L490.3 220.9 L495.2 225.1 L500.2 229.4 L505.1 233.7 L510.0 238.0" />
+                  <path class="result-primer-curve muted-curve dashed-curve" d="M72.0 238.0 L76.9 234.3 L81.8 230.5 L86.8 226.8 L91.7 223.0 L96.6 219.3 L101.5 215.6 L106.4 211.8 L111.4 208.2 L116.3 204.5 L121.2 200.9 L126.1 197.3 L131.1 193.7 L136.0 190.2 L140.9 186.7 L145.8 183.3 L150.7 179.9 L155.7 176.6 L160.6 173.4 L165.5 170.2 L170.4 167.1 L175.3 164.1 L180.3 161.2 L185.2 158.4 L190.1 155.6 L195.0 153.0 L200.0 150.4 L204.9 147.9 L209.8 145.6 L214.7 143.3 L219.6 141.2 L224.6 139.2 L229.5 137.3 L234.4 135.5 L239.3 133.8 L244.2 132.3 L249.2 130.9 L254.1 129.6 L259.0 128.4 L263.9 127.4 L268.9 126.5 L273.8 125.8 L278.7 125.2 L283.6 124.7 L288.5 124.4 L293.5 124.2 L298.4 124.2 L303.3 124.2 L308.2 124.5 L313.1 124.9 L318.1 125.4 L323.0 126.1 L327.9 126.9 L332.8 127.8 L337.8 128.9 L342.7 130.1 L347.6 131.5 L352.5 133.0 L357.4 134.6 L362.4 136.4 L367.3 138.3 L372.2 140.4 L377.1 142.5 L382.0 144.8 L387.0 147.3 L391.9 149.8 L396.8 152.5 L401.7 155.2 L406.7 158.1 L411.6 161.1 L416.5 164.2 L421.4 167.4 L426.3 170.7 L431.3 174.1 L436.2 177.6 L441.1 181.2 L446.0 184.9 L450.9 188.6 L455.9 192.4 L460.8 196.3 L465.7 200.3 L470.6 204.3 L475.6 208.4 L480.5 212.5 L485.4 216.7 L490.3 220.9 L495.2 225.1 L500.2 229.4 L505.1 233.7 L510.0 238.0" />
                 </g>
               </svg>
               <figcaption>Figure 2. Quadrature replaces the continuous integral with weighted point evaluations. The blue cells are the estimate \(Q_r[g]\): each cell width represents \(w_i\), each height is \(g(x_i)\), and each area is one contribution \(w_i g(x_i)\).</figcaption>
@@ -193,8 +193,8 @@ e(r;g) = \left|Q_r[g] - I[g]\right|.
 \]</div>
   <span class="equation-number">(3)</span>
 </div>
-<figure class="open-result-primer-card open-result-paper-figure" id="fig-3">
-              <svg class="open-result-primer-svg open-result-paper-chart-svg" viewBox="0 0 560 306" role="img" aria-label="Conceptual residual between the exact integral and weighted quadrature estimate.">
+<figure class="result-primer-card result-paper-figure" id="fig-3">
+              <svg class="result-primer-svg result-paper-chart-svg" viewBox="0 0 560 306" role="img" aria-label="Conceptual residual between the exact integral and weighted quadrature estimate.">
                 <defs>
                   <clipPath id="conceptResidualPlotClip">
                     <rect x="72" y="72" width="438" height="166" />
@@ -203,58 +203,58 @@ e(r;g) = \left|Q_r[g] - I[g]\right|.
                     <line x1="0" y1="0" x2="0" y2="12" />
                   </pattern>
                 </defs>
-                <text class="open-result-axis-label open-result-figure-title" x="72" y="34">Residual between I[g] and Q<tspan baseline-shift="sub" font-size="9">r</tspan><tspan dx="4">[g]</tspan></text>
-                <path class="open-result-primer-grid" d="M72 74 V238 H510" />
-                <path class="open-result-objective-grid" d="M72 98.0 H510" />
-                <text class="open-result-axis-tick open-result-y-tick" x="56" y="102">1</text>
-                <path class="open-result-axis-notch" d="M66 98 H72" />
-                <text class="open-result-axis-tick" x="72" y="260">0</text>
-                <text class="open-result-axis-tick" x="510" y="260">1</text>
-                <text class="open-result-axis-label open-result-x-axis-title" x="291" y="286">x</text>
-                <text class="open-result-axis-label open-result-objective-y-title" x="34" y="156" transform="rotate(-90 34 156)">g(x)</text>
+                <text class="result-axis-label result-figure-title" x="72" y="34">Residual between I[g] and Q<tspan baseline-shift="sub" font-size="9">r</tspan><tspan dx="4">[g]</tspan></text>
+                <path class="result-primer-grid" d="M72 74 V238 H510" />
+                <path class="result-objective-grid" d="M72 98.0 H510" />
+                <text class="result-axis-tick result-y-tick" x="56" y="102">1</text>
+                <path class="result-axis-notch" d="M66 98 H72" />
+                <text class="result-axis-tick" x="72" y="260">0</text>
+                <text class="result-axis-tick" x="510" y="260">1</text>
+                <text class="result-axis-label result-x-axis-title" x="291" y="286">x</text>
+                <text class="result-axis-label result-objective-y-title" x="34" y="156" transform="rotate(-90 34 156)">g(x)</text>
                 <g clip-path="url(#conceptResidualPlotClip)">
-                  <g class="open-result-concept-samples open-result-concept-samples-muted">
-<g class="open-result-concept-sample ">
+                  <g class="result-concept-samples result-concept-samples-muted">
+<g class="result-concept-sample ">
               <rect x="72.0" y="214.7" width="61.3" height="23.3" />
               <line x1="102.7" y1="238" x2="102.7" y2="214.7" />
               <circle cx="102.7" cy="214.7" r="4.2" />
             </g>
-<g class="open-result-concept-sample ">
+<g class="result-concept-sample ">
               <rect x="133.3" y="161.8" width="92.0" height="76.2" />
               <line x1="179.3" y1="238" x2="179.3" y2="161.8" />
               <circle cx="179.3" cy="161.8" r="4.2" />
             </g>
-<g class="open-result-concept-sample is-accepted">
+<g class="result-concept-sample is-accepted">
               <rect x="225.3" y="124.3" width="131.4" height="113.7" />
               <line x1="291.0" y1="238" x2="291.0" y2="124.3" />
               <circle cx="291.0" cy="124.3" r="4.2" />
             </g>
-<g class="open-result-concept-sample ">
+<g class="result-concept-sample ">
               <rect x="356.7" y="155.8" width="92.0" height="82.2" />
               <line x1="402.7" y1="238" x2="402.7" y2="155.8" />
               <circle cx="402.7" cy="155.8" r="4.2" />
             </g>
-<g class="open-result-concept-sample ">
+<g class="result-concept-sample ">
               <rect x="448.7" y="211.5" width="61.3" height="26.5" />
               <line x1="479.3" y1="238" x2="479.3" y2="211.5" />
               <circle cx="479.3" cy="211.5" r="4.2" />
             </g>
                   </g>
-                  <g class="open-result-residual-regions">
-<path class="open-result-residual-region open-result-residual-negative" d="M72.0 214.7 L133.3 214.7 L133.3 192.1 L130.7 194.0 L128.0 195.9 L125.3 197.8 L122.7 199.8 L120.0 201.8 L117.3 203.7 L114.7 205.7 L112.0 207.7 L109.3 209.7 L106.7 211.7 L104.0 213.7 L101.3 215.7 L98.7 217.7 L96.0 219.7 L93.3 221.8 L90.7 223.8 L88.0 225.8 L85.3 227.9 L82.7 229.9 L80.0 231.9 L77.3 233.9 L74.7 236.0 L72.0 238.0 Z" />
-<path class="open-result-residual-region open-result-residual-negative" d="M133.3 161.8 L225.3 161.8 L225.3 138.9 L221.3 140.5 L217.3 142.2 L213.3 144.0 L209.3 145.8 L205.3 147.7 L201.3 149.7 L197.3 151.8 L193.3 153.9 L189.3 156.1 L185.3 158.3 L181.3 160.6 L177.3 163.0 L173.3 165.4 L169.3 167.8 L165.3 170.4 L161.3 172.9 L157.3 175.5 L153.3 178.2 L149.3 180.9 L145.3 183.6 L141.3 186.4 L137.3 189.2 L133.3 192.1 Z" />
-<path class="open-result-residual-region open-result-residual-negative" d="M225.3 124.3 L356.7 124.3 L356.7 134.4 L351.0 132.5 L345.3 130.8 L339.6 129.3 L333.8 128.0 L328.1 126.9 L322.4 126.0 L316.7 125.2 L311.0 124.7 L305.3 124.3 L299.6 124.2 L293.9 124.2 L288.1 124.4 L282.4 124.8 L276.7 125.4 L271.0 126.2 L265.3 127.2 L259.6 128.3 L253.9 129.7 L248.2 131.2 L242.4 132.8 L236.7 134.7 L231.0 136.7 L225.3 138.9 Z" />
-<path class="open-result-residual-region open-result-residual-negative" d="M356.7 155.8 L448.7 155.8 L448.7 186.9 L444.7 183.9 L440.7 180.9 L436.7 178.0 L432.7 175.2 L428.7 172.4 L424.7 169.6 L420.7 167.0 L416.7 164.4 L412.7 161.8 L408.7 159.4 L404.7 157.0 L400.7 154.6 L396.7 152.4 L392.7 150.2 L388.7 148.1 L384.7 146.1 L380.7 144.2 L376.7 142.3 L372.7 140.6 L368.7 138.9 L364.7 137.3 L360.7 135.8 L356.7 134.4 Z" />
-<path class="open-result-residual-region open-result-residual-negative" d="M448.7 211.5 L510.0 211.5 L510.0 238.0 L507.3 235.7 L504.7 233.3 L502.0 231.0 L499.3 228.7 L496.7 226.3 L494.0 224.0 L491.3 221.7 L488.7 219.5 L486.0 217.2 L483.3 214.9 L480.7 212.7 L478.0 210.4 L475.3 208.2 L472.7 206.0 L470.0 203.8 L467.3 201.6 L464.7 199.5 L462.0 197.3 L459.3 195.2 L456.7 193.1 L454.0 191.0 L451.3 188.9 L448.7 186.9 Z" />
+                  <g class="result-residual-regions">
+<path class="result-residual-region result-residual-negative" d="M72.0 214.7 L133.3 214.7 L133.3 192.1 L130.7 194.0 L128.0 195.9 L125.3 197.8 L122.7 199.8 L120.0 201.8 L117.3 203.7 L114.7 205.7 L112.0 207.7 L109.3 209.7 L106.7 211.7 L104.0 213.7 L101.3 215.7 L98.7 217.7 L96.0 219.7 L93.3 221.8 L90.7 223.8 L88.0 225.8 L85.3 227.9 L82.7 229.9 L80.0 231.9 L77.3 233.9 L74.7 236.0 L72.0 238.0 Z" />
+<path class="result-residual-region result-residual-negative" d="M133.3 161.8 L225.3 161.8 L225.3 138.9 L221.3 140.5 L217.3 142.2 L213.3 144.0 L209.3 145.8 L205.3 147.7 L201.3 149.7 L197.3 151.8 L193.3 153.9 L189.3 156.1 L185.3 158.3 L181.3 160.6 L177.3 163.0 L173.3 165.4 L169.3 167.8 L165.3 170.4 L161.3 172.9 L157.3 175.5 L153.3 178.2 L149.3 180.9 L145.3 183.6 L141.3 186.4 L137.3 189.2 L133.3 192.1 Z" />
+<path class="result-residual-region result-residual-negative" d="M225.3 124.3 L356.7 124.3 L356.7 134.4 L351.0 132.5 L345.3 130.8 L339.6 129.3 L333.8 128.0 L328.1 126.9 L322.4 126.0 L316.7 125.2 L311.0 124.7 L305.3 124.3 L299.6 124.2 L293.9 124.2 L288.1 124.4 L282.4 124.8 L276.7 125.4 L271.0 126.2 L265.3 127.2 L259.6 128.3 L253.9 129.7 L248.2 131.2 L242.4 132.8 L236.7 134.7 L231.0 136.7 L225.3 138.9 Z" />
+<path class="result-residual-region result-residual-negative" d="M356.7 155.8 L448.7 155.8 L448.7 186.9 L444.7 183.9 L440.7 180.9 L436.7 178.0 L432.7 175.2 L428.7 172.4 L424.7 169.6 L420.7 167.0 L416.7 164.4 L412.7 161.8 L408.7 159.4 L404.7 157.0 L400.7 154.6 L396.7 152.4 L392.7 150.2 L388.7 148.1 L384.7 146.1 L380.7 144.2 L376.7 142.3 L372.7 140.6 L368.7 138.9 L364.7 137.3 L360.7 135.8 L356.7 134.4 Z" />
+<path class="result-residual-region result-residual-negative" d="M448.7 211.5 L510.0 211.5 L510.0 238.0 L507.3 235.7 L504.7 233.3 L502.0 231.0 L499.3 228.7 L496.7 226.3 L494.0 224.0 L491.3 221.7 L488.7 219.5 L486.0 217.2 L483.3 214.9 L480.7 212.7 L478.0 210.4 L475.3 208.2 L472.7 206.0 L470.0 203.8 L467.3 201.6 L464.7 199.5 L462.0 197.3 L459.3 195.2 L456.7 193.1 L454.0 191.0 L451.3 188.9 L448.7 186.9 Z" />
                   </g>
-                  <g class="open-result-residual-hatches">
-<path class="open-result-residual-hatch" d="M72.0 214.7 L133.3 214.7 L133.3 192.1 L130.7 194.0 L128.0 195.9 L125.3 197.8 L122.7 199.8 L120.0 201.8 L117.3 203.7 L114.7 205.7 L112.0 207.7 L109.3 209.7 L106.7 211.7 L104.0 213.7 L101.3 215.7 L98.7 217.7 L96.0 219.7 L93.3 221.8 L90.7 223.8 L88.0 225.8 L85.3 227.9 L82.7 229.9 L80.0 231.9 L77.3 233.9 L74.7 236.0 L72.0 238.0 Z" />
-<path class="open-result-residual-hatch" d="M133.3 161.8 L225.3 161.8 L225.3 138.9 L221.3 140.5 L217.3 142.2 L213.3 144.0 L209.3 145.8 L205.3 147.7 L201.3 149.7 L197.3 151.8 L193.3 153.9 L189.3 156.1 L185.3 158.3 L181.3 160.6 L177.3 163.0 L173.3 165.4 L169.3 167.8 L165.3 170.4 L161.3 172.9 L157.3 175.5 L153.3 178.2 L149.3 180.9 L145.3 183.6 L141.3 186.4 L137.3 189.2 L133.3 192.1 Z" />
-<path class="open-result-residual-hatch" d="M225.3 124.3 L356.7 124.3 L356.7 134.4 L351.0 132.5 L345.3 130.8 L339.6 129.3 L333.8 128.0 L328.1 126.9 L322.4 126.0 L316.7 125.2 L311.0 124.7 L305.3 124.3 L299.6 124.2 L293.9 124.2 L288.1 124.4 L282.4 124.8 L276.7 125.4 L271.0 126.2 L265.3 127.2 L259.6 128.3 L253.9 129.7 L248.2 131.2 L242.4 132.8 L236.7 134.7 L231.0 136.7 L225.3 138.9 Z" />
-<path class="open-result-residual-hatch" d="M356.7 155.8 L448.7 155.8 L448.7 186.9 L444.7 183.9 L440.7 180.9 L436.7 178.0 L432.7 175.2 L428.7 172.4 L424.7 169.6 L420.7 167.0 L416.7 164.4 L412.7 161.8 L408.7 159.4 L404.7 157.0 L400.7 154.6 L396.7 152.4 L392.7 150.2 L388.7 148.1 L384.7 146.1 L380.7 144.2 L376.7 142.3 L372.7 140.6 L368.7 138.9 L364.7 137.3 L360.7 135.8 L356.7 134.4 Z" />
-<path class="open-result-residual-hatch" d="M448.7 211.5 L510.0 211.5 L510.0 238.0 L507.3 235.7 L504.7 233.3 L502.0 231.0 L499.3 228.7 L496.7 226.3 L494.0 224.0 L491.3 221.7 L488.7 219.5 L486.0 217.2 L483.3 214.9 L480.7 212.7 L478.0 210.4 L475.3 208.2 L472.7 206.0 L470.0 203.8 L467.3 201.6 L464.7 199.5 L462.0 197.3 L459.3 195.2 L456.7 193.1 L454.0 191.0 L451.3 188.9 L448.7 186.9 Z" />
+                  <g class="result-residual-hatches">
+<path class="result-residual-hatch" d="M72.0 214.7 L133.3 214.7 L133.3 192.1 L130.7 194.0 L128.0 195.9 L125.3 197.8 L122.7 199.8 L120.0 201.8 L117.3 203.7 L114.7 205.7 L112.0 207.7 L109.3 209.7 L106.7 211.7 L104.0 213.7 L101.3 215.7 L98.7 217.7 L96.0 219.7 L93.3 221.8 L90.7 223.8 L88.0 225.8 L85.3 227.9 L82.7 229.9 L80.0 231.9 L77.3 233.9 L74.7 236.0 L72.0 238.0 Z" />
+<path class="result-residual-hatch" d="M133.3 161.8 L225.3 161.8 L225.3 138.9 L221.3 140.5 L217.3 142.2 L213.3 144.0 L209.3 145.8 L205.3 147.7 L201.3 149.7 L197.3 151.8 L193.3 153.9 L189.3 156.1 L185.3 158.3 L181.3 160.6 L177.3 163.0 L173.3 165.4 L169.3 167.8 L165.3 170.4 L161.3 172.9 L157.3 175.5 L153.3 178.2 L149.3 180.9 L145.3 183.6 L141.3 186.4 L137.3 189.2 L133.3 192.1 Z" />
+<path class="result-residual-hatch" d="M225.3 124.3 L356.7 124.3 L356.7 134.4 L351.0 132.5 L345.3 130.8 L339.6 129.3 L333.8 128.0 L328.1 126.9 L322.4 126.0 L316.7 125.2 L311.0 124.7 L305.3 124.3 L299.6 124.2 L293.9 124.2 L288.1 124.4 L282.4 124.8 L276.7 125.4 L271.0 126.2 L265.3 127.2 L259.6 128.3 L253.9 129.7 L248.2 131.2 L242.4 132.8 L236.7 134.7 L231.0 136.7 L225.3 138.9 Z" />
+<path class="result-residual-hatch" d="M356.7 155.8 L448.7 155.8 L448.7 186.9 L444.7 183.9 L440.7 180.9 L436.7 178.0 L432.7 175.2 L428.7 172.4 L424.7 169.6 L420.7 167.0 L416.7 164.4 L412.7 161.8 L408.7 159.4 L404.7 157.0 L400.7 154.6 L396.7 152.4 L392.7 150.2 L388.7 148.1 L384.7 146.1 L380.7 144.2 L376.7 142.3 L372.7 140.6 L368.7 138.9 L364.7 137.3 L360.7 135.8 L356.7 134.4 Z" />
+<path class="result-residual-hatch" d="M448.7 211.5 L510.0 211.5 L510.0 238.0 L507.3 235.7 L504.7 233.3 L502.0 231.0 L499.3 228.7 L496.7 226.3 L494.0 224.0 L491.3 221.7 L488.7 219.5 L486.0 217.2 L483.3 214.9 L480.7 212.7 L478.0 210.4 L475.3 208.2 L472.7 206.0 L470.0 203.8 L467.3 201.6 L464.7 199.5 L462.0 197.3 L459.3 195.2 L456.7 193.1 L454.0 191.0 L451.3 188.9 L448.7 186.9 Z" />
                   </g>
-                  <path class="open-result-primer-curve" d="M72.0 238.0 L76.9 234.3 L81.8 230.5 L86.8 226.8 L91.7 223.0 L96.6 219.3 L101.5 215.6 L106.4 211.8 L111.4 208.2 L116.3 204.5 L121.2 200.9 L126.1 197.3 L131.1 193.7 L136.0 190.2 L140.9 186.7 L145.8 183.3 L150.7 179.9 L155.7 176.6 L160.6 173.4 L165.5 170.2 L170.4 167.1 L175.3 164.1 L180.3 161.2 L185.2 158.4 L190.1 155.6 L195.0 153.0 L200.0 150.4 L204.9 147.9 L209.8 145.6 L214.7 143.3 L219.6 141.2 L224.6 139.2 L229.5 137.3 L234.4 135.5 L239.3 133.8 L244.2 132.3 L249.2 130.9 L254.1 129.6 L259.0 128.4 L263.9 127.4 L268.9 126.5 L273.8 125.8 L278.7 125.2 L283.6 124.7 L288.5 124.4 L293.5 124.2 L298.4 124.2 L303.3 124.2 L308.2 124.5 L313.1 124.9 L318.1 125.4 L323.0 126.1 L327.9 126.9 L332.8 127.8 L337.8 128.9 L342.7 130.1 L347.6 131.5 L352.5 133.0 L357.4 134.6 L362.4 136.4 L367.3 138.3 L372.2 140.4 L377.1 142.5 L382.0 144.8 L387.0 147.3 L391.9 149.8 L396.8 152.5 L401.7 155.2 L406.7 158.1 L411.6 161.1 L416.5 164.2 L421.4 167.4 L426.3 170.7 L431.3 174.1 L436.2 177.6 L441.1 181.2 L446.0 184.9 L450.9 188.6 L455.9 192.4 L460.8 196.3 L465.7 200.3 L470.6 204.3 L475.6 208.4 L480.5 212.5 L485.4 216.7 L490.3 220.9 L495.2 225.1 L500.2 229.4 L505.1 233.7 L510.0 238.0" />
+                  <path class="result-primer-curve" d="M72.0 238.0 L76.9 234.3 L81.8 230.5 L86.8 226.8 L91.7 223.0 L96.6 219.3 L101.5 215.6 L106.4 211.8 L111.4 208.2 L116.3 204.5 L121.2 200.9 L126.1 197.3 L131.1 193.7 L136.0 190.2 L140.9 186.7 L145.8 183.3 L150.7 179.9 L155.7 176.6 L160.6 173.4 L165.5 170.2 L170.4 167.1 L175.3 164.1 L180.3 161.2 L185.2 158.4 L190.1 155.6 L195.0 153.0 L200.0 150.4 L204.9 147.9 L209.8 145.6 L214.7 143.3 L219.6 141.2 L224.6 139.2 L229.5 137.3 L234.4 135.5 L239.3 133.8 L244.2 132.3 L249.2 130.9 L254.1 129.6 L259.0 128.4 L263.9 127.4 L268.9 126.5 L273.8 125.8 L278.7 125.2 L283.6 124.7 L288.5 124.4 L293.5 124.2 L298.4 124.2 L303.3 124.2 L308.2 124.5 L313.1 124.9 L318.1 125.4 L323.0 126.1 L327.9 126.9 L332.8 127.8 L337.8 128.9 L342.7 130.1 L347.6 131.5 L352.5 133.0 L357.4 134.6 L362.4 136.4 L367.3 138.3 L372.2 140.4 L377.1 142.5 L382.0 144.8 L387.0 147.3 L391.9 149.8 L396.8 152.5 L401.7 155.2 L406.7 158.1 L411.6 161.1 L416.5 164.2 L421.4 167.4 L426.3 170.7 L431.3 174.1 L436.2 177.6 L441.1 181.2 L446.0 184.9 L450.9 188.6 L455.9 192.4 L460.8 196.3 L465.7 200.3 L470.6 204.3 L475.6 208.4 L480.5 212.5 L485.4 216.7 L490.3 220.9 L495.2 225.1 L500.2 229.4 L505.1 233.7 L510.0 238.0" />
                 </g>
               </svg>
               <figcaption>Figure 3. Conceptual residual diagnostic. Local over- and under-estimation can coexist; the reported scalar residual is the absolute net difference between the quadrature estimate and the exact integral.</figcaption>
@@ -287,9 +287,9 @@ J(r) = \sum_{j=1}^{3} \alpha_j\,e_j(r).
 \]</div>
   <span class="equation-number">(6)</span>
 </div>
-<figure class="open-result-paper-table open-result-contract-table" id="table-1">
-          <div class="open-result-table-wrap">
-            <table class="open-result-table">
+<figure class="result-paper-table result-contract-table" id="table-1">
+          <div class="result-table-wrap">
+            <table class="result-table">
               <thead>
                 <tr>
                   <th>Component</th>
@@ -325,116 +325,116 @@ J(r) = \sum_{j=1}^{3} \alpha_j\,e_j(r).
 <p>The public bundle identifies the integrand suite and objective direction, but it does not expose numeric component weights \(\alpha_j\). <a href="#table-1">Table 1</a> therefore fixes the public residual components without inventing unpublished objective weights or mixing in accepted-candidate outcomes. In plain terms: the table shows what was tested and where the baseline started; it does not ask the reader to trust an unpublished weighting scheme.</p>
 <h4>Run baseline</h4>
 <p>The run baseline \(r_0\) is the first public rule in the curated trace. It fixes the comparison point before candidate selection. Every improvement reported later is measured relative to this same baseline.</p>
-<figure class="open-result-primer-card open-result-paper-figure open-result-single-rule-figure" id="fig-4">
-          <svg class="open-result-primer-svg open-result-accepted-rule-svg open-result-paper-chart-svg" viewBox="0 0 560 280" role="img" aria-label="Run baseline quadrature rule shown as node position and normalized weight.">
-            <text class="open-result-axis-label open-result-objective-y-title" x="34" y="130" transform="rotate(-90 34 130)">normalized weight w<tspan baseline-shift="sub" font-size="8">i</tspan></text>
-            <g class="open-result-objective-legend open-result-single-rule-legend" transform="translate(420 34)">
+<figure class="result-primer-card result-paper-figure result-single-rule-figure" id="fig-4">
+          <svg class="result-primer-svg result-accepted-rule-svg result-paper-chart-svg" viewBox="0 0 560 280" role="img" aria-label="Run baseline quadrature rule shown as node position and normalized weight.">
+            <text class="result-axis-label result-objective-y-title" x="34" y="130" transform="rotate(-90 34 130)">normalized weight w<tspan baseline-shift="sub" font-size="8">i</tspan></text>
+            <g class="result-objective-legend result-single-rule-legend" transform="translate(420 34)">
               <g transform="translate(0 0)">
-                <circle class="open-result-legend-baseline-dot" cx="0" cy="0" r="3.8" />
+                <circle class="result-legend-baseline-dot" cx="0" cy="0" r="3.8" />
                 <text x="16" y="4">run baseline</text>
               </g>
             </g>
-            <g class="open-result-rule-panel">
-              <text class="open-result-axis-label open-result-figure-title" x="82" y="36">Run baseline</text>
+            <g class="result-rule-panel">
+              <text class="result-axis-label result-figure-title" x="82" y="36">Run baseline</text>
 
               <g>
-                <path class="open-result-objective-grid" d="M82 186.0 H512" />
-                <text class="open-result-axis-tick open-result-objective-y-label" x="68" y="190.0">0</text>
+                <path class="result-objective-grid" d="M82 186.0 H512" />
+                <text class="result-axis-tick result-objective-y-label" x="68" y="190.0">0</text>
               </g>
 <g>
-                <path class="open-result-objective-grid" d="M82 130.0 H512" />
-                <text class="open-result-axis-tick open-result-objective-y-label" x="68" y="134.0">0.5</text>
+                <path class="result-objective-grid" d="M82 130.0 H512" />
+                <text class="result-axis-tick result-objective-y-label" x="68" y="134.0">0.5</text>
               </g>
 <g>
-                <path class="open-result-objective-grid" d="M82 74.0 H512" />
-                <text class="open-result-axis-tick open-result-objective-y-label" x="68" y="78.0">1</text>
+                <path class="result-objective-grid" d="M82 74.0 H512" />
+                <text class="result-axis-tick result-objective-y-label" x="68" y="78.0">1</text>
               </g>
-              <path class="open-result-rule-paper-axis" d="M82 74 V186 H512" />
-              <text class="open-result-axis-tick" x="82" y="204">0</text>
-              <text class="open-result-axis-tick" x="297" y="204">0.5</text>
-              <text class="open-result-axis-tick" x="512" y="204">1</text>
+              <path class="result-rule-paper-axis" d="M82 74 V186 H512" />
+              <text class="result-axis-tick" x="82" y="204">0</text>
+              <text class="result-axis-tick" x="297" y="204">0.5</text>
+              <text class="result-axis-tick" x="512" y="204">1</text>
             </g>
-            <g class="open-result-baseline-node">
+            <g class="result-baseline-node">
                 <line x1="82.0" y1="186.0" x2="82.0" y2="186.0" />
                 <circle cx="82.0" cy="186.0" r="3.1" />
               </g>
-<g class="open-result-baseline-node">
+<g class="result-baseline-node">
                 <line x1="82.0" y1="186.0" x2="82.0" y2="186.0" />
                 <circle cx="82.0" cy="186.0" r="3.1" />
               </g>
-<g class="open-result-baseline-node">
+<g class="result-baseline-node">
                 <line x1="130.5" y1="186.0" x2="130.5" y2="186.0" />
                 <circle cx="130.5" cy="186.0" r="3.1" />
               </g>
-<g class="open-result-baseline-node">
+<g class="result-baseline-node">
                 <line x1="130.5" y1="186.0" x2="130.5" y2="186.0" />
                 <circle cx="130.5" cy="186.0" r="3.1" />
               </g>
-<g class="open-result-baseline-node">
+<g class="result-baseline-node">
                 <line x1="297.0" y1="186.0" x2="297.0" y2="74.0" />
                 <circle cx="297.0" cy="74.0" r="4.4" />
               </g>
-            <text class="open-result-axis-label open-result-x-axis-title" x="297" y="260">node position x<tspan baseline-shift="sub" font-size="8">i</tspan></text>
+            <text class="result-axis-label result-x-axis-title" x="297" y="260">node position x<tspan baseline-shift="sub" font-size="8">i</tspan></text>
           </svg>
           <figcaption>Figure 4. Run baseline \(r_0\). This fixed rule anchors the residual and objective improvements reported later.</figcaption>
         </figure>
 <p>All objective and residual improvements reported below are measured against this same run baseline, whose contracted objective is \(J(r_0)=688.676231\).</p>
 <h3>3. Accepted candidate</h3>
 <p>The accepted candidate is the five-node rule shown in <a href="#fig-5">Figure 5</a>. This is the object being reported: five sample locations and five normalized weights. The figure is the primary definition of the node placement and weights; it should be read against the run baseline in <a href="#fig-4">Figure 4</a> before interpreting the objective change.</p>
-<figure class="open-result-primer-card open-result-paper-figure open-result-single-rule-figure" id="fig-5">
-          <svg class="open-result-primer-svg open-result-accepted-rule-svg open-result-paper-chart-svg" viewBox="0 0 560 280" role="img" aria-label="Accepted five node quadrature rule shown as node position and normalized weight.">
-            <text class="open-result-axis-label open-result-objective-y-title" x="34" y="130" transform="rotate(-90 34 130)">normalized weight w<tspan baseline-shift="sub" font-size="8">i</tspan></text>
-            <g class="open-result-objective-legend open-result-single-rule-legend" transform="translate(420 34)">
+<figure class="result-primer-card result-paper-figure result-single-rule-figure" id="fig-5">
+          <svg class="result-primer-svg result-accepted-rule-svg result-paper-chart-svg" viewBox="0 0 560 280" role="img" aria-label="Accepted five node quadrature rule shown as node position and normalized weight.">
+            <text class="result-axis-label result-objective-y-title" x="34" y="130" transform="rotate(-90 34 130)">normalized weight w<tspan baseline-shift="sub" font-size="8">i</tspan></text>
+            <g class="result-objective-legend result-single-rule-legend" transform="translate(420 34)">
               <g transform="translate(0 0)">
-                <circle class="open-result-legend-accepted-dot" cx="0" cy="0" r="3.8" />
+                <circle class="result-legend-accepted-dot" cx="0" cy="0" r="3.8" />
                 <text x="16" y="4">accepted</text>
               </g>
             </g>
-            <g class="open-result-rule-panel">
-              <text class="open-result-axis-label open-result-figure-title" x="82" y="36">Accepted rule</text>
+            <g class="result-rule-panel">
+              <text class="result-axis-label result-figure-title" x="82" y="36">Accepted rule</text>
 
               <g>
-                <path class="open-result-objective-grid" d="M82 186.0 H512" />
-                <text class="open-result-axis-tick open-result-objective-y-label" x="68" y="190.0">0</text>
+                <path class="result-objective-grid" d="M82 186.0 H512" />
+                <text class="result-axis-tick result-objective-y-label" x="68" y="190.0">0</text>
               </g>
 <g>
-                <path class="open-result-objective-grid" d="M82 141.2 H512" />
-                <text class="open-result-axis-tick open-result-objective-y-label" x="68" y="145.2">0.1</text>
+                <path class="result-objective-grid" d="M82 141.2 H512" />
+                <text class="result-axis-tick result-objective-y-label" x="68" y="145.2">0.1</text>
               </g>
 <g>
-                <path class="open-result-objective-grid" d="M82 96.4 H512" />
-                <text class="open-result-axis-tick open-result-objective-y-label" x="68" y="100.4">0.2</text>
+                <path class="result-objective-grid" d="M82 96.4 H512" />
+                <text class="result-axis-tick result-objective-y-label" x="68" y="100.4">0.2</text>
               </g>
 <g>
-                <path class="open-result-objective-grid" d="M82 74.0 H512" />
-                <text class="open-result-axis-tick open-result-objective-y-label" x="68" y="78.0">0.25</text>
+                <path class="result-objective-grid" d="M82 74.0 H512" />
+                <text class="result-axis-tick result-objective-y-label" x="68" y="78.0">0.25</text>
               </g>
-              <path class="open-result-rule-paper-axis" d="M82 74 V186 H512" />
-              <text class="open-result-axis-tick" x="82" y="204">0</text>
-              <text class="open-result-axis-tick" x="297" y="204">0.5</text>
-              <text class="open-result-axis-tick" x="512" y="204">1</text>
+              <path class="result-rule-paper-axis" d="M82 74 V186 H512" />
+              <text class="result-axis-tick" x="82" y="204">0</text>
+              <text class="result-axis-tick" x="297" y="204">0.5</text>
+              <text class="result-axis-tick" x="512" y="204">1</text>
             </g>
-            <g class="open-result-accepted-node">
+            <g class="result-accepted-node">
                 <line x1="115.2" y1="186.0" x2="115.2" y2="96.4" />
                 <circle cx="115.2" cy="96.4" r="4.4" />
               </g>
-<g class="open-result-accepted-node">
+<g class="result-accepted-node">
                 <line x1="221.9" y1="186.0" x2="221.9" y2="96.3" />
                 <circle cx="221.9" cy="96.3" r="4.4" />
               </g>
-<g class="open-result-accepted-node">
+<g class="result-accepted-node">
                 <line x1="297.0" y1="186.0" x2="297.0" y2="96.3" />
                 <circle cx="297.0" cy="96.3" r="4.4" />
               </g>
-<g class="open-result-accepted-node">
+<g class="result-accepted-node">
                 <line x1="372.1" y1="186.0" x2="372.1" y2="96.4" />
                 <circle cx="372.1" cy="96.4" r="4.4" />
               </g>
-<g class="open-result-accepted-node">
+<g class="result-accepted-node">
                 <line x1="478.8" y1="186.0" x2="478.8" y2="96.6" />
                 <circle cx="478.8" cy="96.6" r="4.4" />
               </g>
-            <text class="open-result-axis-label open-result-x-axis-title" x="297" y="260">node position x<tspan baseline-shift="sub" font-size="8">i</tspan></text>
+            <text class="result-axis-label result-x-axis-title" x="297" y="260">node position x<tspan baseline-shift="sub" font-size="8">i</tspan></text>
           </svg>
           <figcaption>Figure 5. Accepted five-node rule in node-position and normalized-weight coordinates. The near-uniform weights and inward node placement define the candidate evaluated below.</figcaption>
         </figure>
@@ -451,174 +451,174 @@ p=1.7.
   <span class="equation-number">(7)</span>
 </div>
 <p>The accepted implementation is included here because it is part of the candidate definition, not only a replay appendix. The code is short enough for a reader to verify that the reported rule is generated by the stated transformation.</p>
-<figure class="open-result-paper-code open-result-code-figure" id="listing-1">
+<figure class="result-paper-code result-code-figure" id="listing-1">
           <pre><code><span class="code-line"><span class="line-no">1</span><span class="line-src"><span class="py-keyword">def</span> quadrature_rule(spec: QuadratureSpec) -&gt; QuadratureRule:</span></span><span class="code-line"><span class="line-no">2</span><span class="line-src">    &quot;&quot;&quot;</span></span><span class="code-line"><span class="line-no">3</span><span class="line-src">    Construct a quadrature rule using Gauss-Legendre nodes with deterministic inward remapping.</span></span><span class="code-line"><span class="line-no">4</span><span class="line-src">    &quot;&quot;&quot;</span></span><span class="code-line"><span class="line-no">5</span><span class="line-src">    n = <span class="py-builtin">max</span>(1, <span class="py-builtin">int</span>(spec.n_points))</span></span><span class="code-line"><span class="line-no">6</span><span class="line-src">    <span class="py-keyword">if</span> n == 1:</span></span><span class="code-line"><span class="line-no">7</span><span class="line-src">        <span class="py-keyword">return</span> QuadratureRule(nodes=[0.5], weights=[1.0])</span></span><span class="code-line"><span class="line-no">8</span><span class="line-src"> </span></span><span class="code-line"><span class="line-no">9</span><span class="line-src">    nodes, weights = np.polynomial.legendre.leggauss(n)</span></span><span class="code-line"><span class="line-no">10</span><span class="line-src">    <span class="py-keyword">if</span> n &gt;= 2:</span></span><span class="code-line"><span class="line-no">11</span><span class="line-src">        alpha = 1.7</span></span><span class="code-line"><span class="line-no">12</span><span class="line-src">        nodes = np.sign(nodes) * (np.abs(nodes) ** alpha)</span></span><span class="code-line"><span class="line-no">13</span><span class="line-src"> </span></span><span class="code-line"><span class="line-no">14</span><span class="line-src">    mapped_nodes = 0.5 * (nodes + 1.0)</span></span><span class="code-line"><span class="line-no">15</span><span class="line-src">    mapped_weights = 0.5 * weights</span></span><span class="code-line"><span class="line-no">16</span><span class="line-src">    rule = QuadratureRule(nodes=<span class="py-builtin">list</span>(mapped_nodes), weights=<span class="py-builtin">list</span>(mapped_weights))</span></span><span class="code-line"><span class="line-no">17</span><span class="line-src"> </span></span><span class="code-line"><span class="line-no">18</span><span class="line-src">    <span class="py-keyword">if</span> <span class="py-builtin">getattr</span>(spec, &quot;enforce_symmetry&quot;, <span class="py-constant">False</span>):</span></span><span class="code-line"><span class="line-no">19</span><span class="line-src">        n_half = n // 2</span></span><span class="code-line"><span class="line-no">20</span><span class="line-src">        <span class="py-keyword">for</span> i <span class="py-keyword">in</span> <span class="py-builtin">range</span>(n_half):</span></span><span class="code-line"><span class="line-no">21</span><span class="line-src">            avg_node = 0.5 * (rule.nodes[i] + (1.0 - rule.nodes[n - 1 - i]))</span></span><span class="code-line"><span class="line-no">22</span><span class="line-src">            rule.nodes[i] = avg_node</span></span><span class="code-line"><span class="line-no">23</span><span class="line-src">            rule.nodes[n - 1 - i] = 1.0 - avg_node</span></span><span class="code-line"><span class="line-no">24</span><span class="line-src">            avg_weight = 0.5 * (rule.weights[i] + rule.weights[n - 1 - i])</span></span><span class="code-line"><span class="line-no">25</span><span class="line-src">            rule.weights[i] = avg_weight</span></span><span class="code-line"><span class="line-no">26</span><span class="line-src">            rule.weights[n - 1 - i] = avg_weight</span></span><span class="code-line"><span class="line-no">27</span><span class="line-src"> </span></span><span class="code-line"><span class="line-no">28</span><span class="line-src">    <span class="py-keyword">return</span> _renormalize(rule)</span></span></code></pre>
           <figcaption>Listing 1. Accepted candidate implementation.</figcaption>
         </figure>
 <h4>Candidate results</h4>
 <p>The result is read in two layers. <a href="#fig-6">Figure 6</a> and <a href="#table-2">Table 2</a> show the governed acceptance objective; <a href="#fig-7">Figure 7</a> and <a href="#table-3">Table 3</a> show where the accepted rule leaves residual error on the public functions.</p>
-<figure class="open-result-primer-card open-result-paper-figure open-result-objective-figure" id="fig-6">
-          <svg class="open-result-primer-svg open-result-objective-svg" viewBox="0 0 560 328" role="img" aria-label="Best so far objective curve across the curated public trace.">
-            <text class="open-result-axis-label open-result-figure-title" x="82" y="34">Best-so-far acceptance objective (lower is better)</text>
-            <g class="open-result-objective-legend" transform="translate(82 48)">
+<figure class="result-primer-card result-paper-figure result-objective-figure" id="fig-6">
+          <svg class="result-primer-svg result-objective-svg" viewBox="0 0 560 328" role="img" aria-label="Best so far objective curve across the curated public trace.">
+            <text class="result-axis-label result-figure-title" x="82" y="34">Best-so-far acceptance objective (lower is better)</text>
+            <g class="result-objective-legend" transform="translate(82 48)">
               <g transform="translate(0 0)">
-                <circle class="open-result-objective-legend-proposal" cx="0" cy="0" r="2.4" />
+                <circle class="result-objective-legend-proposal" cx="0" cy="0" r="2.4" />
                 <text x="12" y="4">scored candidate</text>
               </g>
               <g transform="translate(118 0)">
-                <line class="open-result-objective-legend-best" x1="0" y1="0" x2="16" y2="0" />
+                <line class="result-objective-legend-best" x1="0" y1="0" x2="16" y2="0" />
                 <text x="24" y="4">best-so-far objective</text>
               </g>
               <g transform="translate(286 0)">
-                <circle class="open-result-legend-baseline-dot" cx="0" cy="0" r="3.4" />
+                <circle class="result-legend-baseline-dot" cx="0" cy="0" r="3.4" />
                 <text x="16" y="4">baseline</text>
               </g>
               <g transform="translate(374 0)">
-                <circle class="open-result-legend-accepted-dot" cx="0" cy="0" r="3.8" />
+                <circle class="result-legend-accepted-dot" cx="0" cy="0" r="3.8" />
                 <text x="16" y="4">accepted</text>
               </g>
             </g>
             <g>
-                <path class="open-result-objective-grid" d="M82 260.0 H512" />
-                <text class="open-result-axis-tick open-result-objective-y-label" x="64" y="264.0">0</text>
+                <path class="result-objective-grid" d="M82 260.0 H512" />
+                <text class="result-axis-tick result-objective-y-label" x="64" y="264.0">0</text>
               </g>
 <g>
-                <path class="open-result-objective-grid" d="M82 206.9 H512" />
-                <text class="open-result-axis-tick open-result-objective-y-label" x="64" y="210.9">200</text>
+                <path class="result-objective-grid" d="M82 206.9 H512" />
+                <text class="result-axis-tick result-objective-y-label" x="64" y="210.9">200</text>
               </g>
 <g>
-                <path class="open-result-objective-grid" d="M82 153.7 H512" />
-                <text class="open-result-axis-tick open-result-objective-y-label" x="64" y="157.7">400</text>
+                <path class="result-objective-grid" d="M82 153.7 H512" />
+                <text class="result-axis-tick result-objective-y-label" x="64" y="157.7">400</text>
               </g>
 <g>
-                <path class="open-result-objective-grid" d="M82 100.6 H512" />
-                <text class="open-result-axis-tick open-result-objective-y-label" x="64" y="104.6">600</text>
+                <path class="result-objective-grid" d="M82 100.6 H512" />
+                <text class="result-axis-tick result-objective-y-label" x="64" y="104.6">600</text>
               </g>
 <g>
-                <path class="open-result-objective-grid" d="M82 74.0 H512" />
-                <text class="open-result-axis-tick open-result-objective-y-label" x="64" y="78.0">700</text>
+                <path class="result-objective-grid" d="M82 74.0 H512" />
+                <text class="result-axis-tick result-objective-y-label" x="64" y="78.0">700</text>
               </g>
-            <path class="open-result-rule-paper-axis" d="M82 74 V260 H512" />
+            <path class="result-rule-paper-axis" d="M82 74 V260 H512" />
             <g>
-                <path class="open-result-objective-x-tick" d="M82.0 260 V265.0" />
-                <text class="open-result-axis-tick" x="82.0" y="282">0</text>
+                <path class="result-objective-x-tick" d="M82.0 260 V265.0" />
+                <text class="result-axis-tick" x="82.0" y="282">0</text>
               </g>
 <g>
-                <path class="open-result-objective-x-tick" d="M184.4 260 V265.0" />
-                <text class="open-result-axis-tick" x="184.4" y="282">20</text>
+                <path class="result-objective-x-tick" d="M184.4 260 V265.0" />
+                <text class="result-axis-tick" x="184.4" y="282">20</text>
               </g>
 <g>
-                <path class="open-result-objective-x-tick" d="M286.8 260 V265.0" />
-                <text class="open-result-axis-tick" x="286.8" y="282">40</text>
+                <path class="result-objective-x-tick" d="M286.8 260 V265.0" />
+                <text class="result-axis-tick" x="286.8" y="282">40</text>
               </g>
 <g>
-                <path class="open-result-objective-x-tick" d="M389.1 260 V265.0" />
-                <text class="open-result-axis-tick" x="389.1" y="282">60</text>
+                <path class="result-objective-x-tick" d="M389.1 260 V265.0" />
+                <text class="result-axis-tick" x="389.1" y="282">60</text>
               </g>
 <g>
-                <path class="open-result-objective-x-tick" d="M512.0 260 V265.0" />
-                <text class="open-result-axis-tick" x="512.0" y="282">84</text>
+                <path class="result-objective-x-tick" d="M512.0 260 V265.0" />
+                <text class="result-axis-tick" x="512.0" y="282">84</text>
               </g>
-            <text class="open-result-axis-label open-result-x-axis-title" x="297" y="306">candidate index</text>
-            <text class="open-result-axis-label open-result-objective-y-title" x="34" y="167" transform="rotate(-90 34 167)">J(r)</text>
-            <g><circle class="open-result-objective-proposal" cx="82.0" cy="77.0" r="2.1" />
-<circle class="open-result-objective-proposal" cx="87.1" cy="74.1" r="2.1" />
-<circle class="open-result-objective-proposal" cx="92.2" cy="97.1" r="2.1" />
-<circle class="open-result-objective-proposal" cx="97.4" cy="77.0" r="2.1" />
-<circle class="open-result-objective-proposal" cx="102.5" cy="77.0" r="2.1" />
-<circle class="open-result-objective-proposal" cx="107.6" cy="104.8" r="2.1" />
-<circle class="open-result-objective-proposal" cx="112.7" cy="97.1" r="2.1" />
-<circle class="open-result-objective-proposal" cx="117.8" cy="74.1" r="2.1" />
-<circle class="open-result-objective-proposal" cx="123.0" cy="174.9" r="2.1" />
-<circle class="open-result-objective-proposal" cx="128.1" cy="147.7" r="2.1" />
-<circle class="open-result-objective-proposal" cx="133.2" cy="97.1" r="2.1" />
-<circle class="open-result-objective-proposal" cx="138.3" cy="174.9" r="2.1" />
-<circle class="open-result-objective-proposal" cx="143.4" cy="147.7" r="2.1" />
-<circle class="open-result-objective-proposal" cx="148.5" cy="77.0" r="2.1" />
-<circle class="open-result-objective-proposal" cx="153.7" cy="174.9" r="2.1" />
-<circle class="open-result-objective-proposal" cx="158.8" cy="77.0" r="2.1" />
-<circle class="open-result-objective-proposal" cx="163.9" cy="97.1" r="2.1" />
-<circle class="open-result-objective-proposal" cx="169.0" cy="97.1" r="2.1" />
-<circle class="open-result-objective-proposal" cx="174.1" cy="89.3" r="2.1" />
-<circle class="open-result-objective-proposal" cx="179.3" cy="174.9" r="2.1" />
-<circle class="open-result-objective-proposal" cx="184.4" cy="89.3" r="2.1" />
-<circle class="open-result-objective-proposal" cx="189.5" cy="97.1" r="2.1" />
-<circle class="open-result-objective-proposal" cx="194.6" cy="147.7" r="2.1" />
-<circle class="open-result-objective-proposal" cx="199.7" cy="147.7" r="2.1" />
-<circle class="open-result-objective-proposal" cx="204.9" cy="189.9" r="2.1" />
-<circle class="open-result-objective-proposal" cx="210.0" cy="89.3" r="2.1" />
-<circle class="open-result-objective-proposal" cx="215.1" cy="198.9" r="2.1" />
-<circle class="open-result-objective-proposal" cx="220.2" cy="95.7" r="2.1" />
-<circle class="open-result-objective-proposal" cx="225.3" cy="77.0" r="2.1" />
-<circle class="open-result-objective-proposal" cx="230.5" cy="89.3" r="2.1" />
-<circle class="open-result-objective-proposal" cx="235.6" cy="89.3" r="2.1" />
-<circle class="open-result-objective-proposal" cx="240.7" cy="89.3" r="2.1" />
-<circle class="open-result-objective-proposal" cx="245.8" cy="151.4" r="2.1" />
-<circle class="open-result-objective-proposal" cx="250.9" cy="157.7" r="2.1" />
-<circle class="open-result-objective-proposal" cx="256.0" cy="89.3" r="2.1" />
-<circle class="open-result-objective-proposal" cx="261.2" cy="89.3" r="2.1" />
-<circle class="open-result-objective-proposal" cx="266.3" cy="97.1" r="2.1" />
-<circle class="open-result-objective-proposal" cx="271.4" cy="89.3" r="2.1" />
-<circle class="open-result-objective-proposal" cx="276.5" cy="185.1" r="2.1" />
-<circle class="open-result-objective-proposal" cx="281.6" cy="97.1" r="2.1" />
-<circle class="open-result-objective-proposal" cx="286.8" cy="185.1" r="2.1" />
-<circle class="open-result-objective-proposal" cx="291.9" cy="218.2" r="2.1" />
-<circle class="open-result-objective-proposal" cx="297.0" cy="218.2" r="2.1" />
-<circle class="open-result-objective-proposal" cx="302.1" cy="160.0" r="2.1" />
-<circle class="open-result-objective-proposal" cx="307.2" cy="157.7" r="2.1" />
-<circle class="open-result-objective-proposal" cx="312.4" cy="229.6" r="2.1" />
-<circle class="open-result-objective-proposal" cx="317.5" cy="194.5" r="2.1" />
-<circle class="open-result-objective-proposal" cx="322.6" cy="198.9" r="2.1" />
-<circle class="open-result-objective-proposal" cx="327.7" cy="218.2" r="2.1" />
-<circle class="open-result-objective-proposal" cx="332.8" cy="218.2" r="2.1" />
-<circle class="open-result-objective-proposal" cx="338.0" cy="194.5" r="2.1" />
-<circle class="open-result-objective-proposal" cx="343.1" cy="89.3" r="2.1" />
-<circle class="open-result-objective-proposal" cx="348.2" cy="137.9" r="2.1" />
-<circle class="open-result-objective-proposal" cx="353.3" cy="196.9" r="2.1" />
-<circle class="open-result-objective-proposal" cx="358.4" cy="174.9" r="2.1" />
-<circle class="open-result-objective-proposal" cx="363.5" cy="140.6" r="2.1" />
-<circle class="open-result-objective-proposal" cx="368.7" cy="97.1" r="2.1" />
-<circle class="open-result-objective-proposal" cx="373.8" cy="174.9" r="2.1" />
-<circle class="open-result-objective-proposal" cx="378.9" cy="220.6" r="2.1" />
-<circle class="open-result-objective-proposal" cx="384.0" cy="151.4" r="2.1" />
-<circle class="open-result-objective-proposal" cx="389.1" cy="97.1" r="2.1" />
-<circle class="open-result-objective-proposal" cx="394.3" cy="147.7" r="2.1" />
-<circle class="open-result-objective-proposal" cx="399.4" cy="147.7" r="2.1" />
-<circle class="open-result-objective-proposal" cx="404.5" cy="151.4" r="2.1" />
-<circle class="open-result-objective-proposal" cx="409.6" cy="226.5" r="2.1" />
-<circle class="open-result-objective-proposal" cx="414.7" cy="89.3" r="2.1" />
-<circle class="open-result-objective-proposal" cx="419.9" cy="157.7" r="2.1" />
-<circle class="open-result-objective-proposal" cx="425.0" cy="163.7" r="2.1" />
-<circle class="open-result-objective-proposal" cx="430.1" cy="147.7" r="2.1" />
-<circle class="open-result-objective-proposal" cx="435.2" cy="225.0" r="2.1" />
-<circle class="open-result-objective-proposal" cx="440.3" cy="174.9" r="2.1" />
-<circle class="open-result-objective-proposal" cx="445.5" cy="157.7" r="2.1" />
-<circle class="open-result-objective-proposal" cx="450.6" cy="218.2" r="2.1" />
-<circle class="open-result-objective-proposal" cx="455.7" cy="174.9" r="2.1" />
-<circle class="open-result-objective-proposal" cx="460.8" cy="151.4" r="2.1" />
-<circle class="open-result-objective-proposal" cx="465.9" cy="224.6" r="2.1" />
-<circle class="open-result-objective-proposal" cx="471.0" cy="137.9" r="2.1" />
-<circle class="open-result-objective-proposal" cx="476.2" cy="151.4" r="2.1" />
-<circle class="open-result-objective-proposal" cx="481.3" cy="226.5" r="2.1" />
-<circle class="open-result-objective-proposal" cx="486.4" cy="155.6" r="2.1" />
-<circle class="open-result-objective-proposal" cx="491.5" cy="163.7" r="2.1" />
-<circle class="open-result-objective-proposal" cx="496.6" cy="157.7" r="2.1" />
-<circle class="open-result-objective-proposal" cx="501.8" cy="174.9" r="2.1" />
-<circle class="open-result-objective-proposal" cx="506.9" cy="137.9" r="2.1" />
-<circle class="open-result-objective-proposal" cx="512.0" cy="224.6" r="2.1" /></g>
-            <path class="open-result-objective-best" d="M82.0 77.0 L87.1 77.0 L92.2 97.1 L97.4 97.1 L102.5 97.1 L107.6 104.8 L112.7 104.8 L117.8 104.8 L123.0 174.9 L128.1 174.9 L133.2 174.9 L138.3 174.9 L143.4 174.9 L148.5 174.9 L153.7 174.9 L158.8 174.9 L163.9 174.9 L169.0 174.9 L174.1 174.9 L179.3 174.9 L184.4 174.9 L189.5 174.9 L194.6 174.9 L199.7 174.9 L204.9 189.9 L210.0 189.9 L215.1 198.9 L220.2 198.9 L225.3 198.9 L230.5 198.9 L235.6 198.9 L240.7 198.9 L245.8 198.9 L250.9 198.9 L256.0 198.9 L261.2 198.9 L266.3 198.9 L271.4 198.9 L276.5 198.9 L281.6 198.9 L286.8 198.9 L291.9 218.2 L297.0 218.2 L302.1 218.2 L307.2 218.2 L312.4 229.6 L317.5 229.6 L322.6 229.6 L327.7 229.6 L332.8 229.6 L338.0 229.6 L343.1 229.6 L348.2 229.6 L353.3 229.6 L358.4 229.6 L363.5 229.6 L368.7 229.6 L373.8 229.6 L378.9 229.6 L384.0 229.6 L389.1 229.6 L394.3 229.6 L399.4 229.6 L404.5 229.6 L409.6 229.6 L414.7 229.6 L419.9 229.6 L425.0 229.6 L430.1 229.6 L435.2 229.6 L440.3 229.6 L445.5 229.6 L450.6 229.6 L455.7 229.6 L460.8 229.6 L465.9 229.6 L471.0 229.6 L476.2 229.6 L481.3 229.6 L486.4 229.6 L491.5 229.6 L496.6 229.6 L501.8 229.6 L506.9 229.6 L512.0 229.6" />
-            <g class="open-result-objective-baseline">
+            <text class="result-axis-label result-x-axis-title" x="297" y="306">candidate index</text>
+            <text class="result-axis-label result-objective-y-title" x="34" y="167" transform="rotate(-90 34 167)">J(r)</text>
+            <g><circle class="result-objective-proposal" cx="82.0" cy="77.0" r="2.1" />
+<circle class="result-objective-proposal" cx="87.1" cy="74.1" r="2.1" />
+<circle class="result-objective-proposal" cx="92.2" cy="97.1" r="2.1" />
+<circle class="result-objective-proposal" cx="97.4" cy="77.0" r="2.1" />
+<circle class="result-objective-proposal" cx="102.5" cy="77.0" r="2.1" />
+<circle class="result-objective-proposal" cx="107.6" cy="104.8" r="2.1" />
+<circle class="result-objective-proposal" cx="112.7" cy="97.1" r="2.1" />
+<circle class="result-objective-proposal" cx="117.8" cy="74.1" r="2.1" />
+<circle class="result-objective-proposal" cx="123.0" cy="174.9" r="2.1" />
+<circle class="result-objective-proposal" cx="128.1" cy="147.7" r="2.1" />
+<circle class="result-objective-proposal" cx="133.2" cy="97.1" r="2.1" />
+<circle class="result-objective-proposal" cx="138.3" cy="174.9" r="2.1" />
+<circle class="result-objective-proposal" cx="143.4" cy="147.7" r="2.1" />
+<circle class="result-objective-proposal" cx="148.5" cy="77.0" r="2.1" />
+<circle class="result-objective-proposal" cx="153.7" cy="174.9" r="2.1" />
+<circle class="result-objective-proposal" cx="158.8" cy="77.0" r="2.1" />
+<circle class="result-objective-proposal" cx="163.9" cy="97.1" r="2.1" />
+<circle class="result-objective-proposal" cx="169.0" cy="97.1" r="2.1" />
+<circle class="result-objective-proposal" cx="174.1" cy="89.3" r="2.1" />
+<circle class="result-objective-proposal" cx="179.3" cy="174.9" r="2.1" />
+<circle class="result-objective-proposal" cx="184.4" cy="89.3" r="2.1" />
+<circle class="result-objective-proposal" cx="189.5" cy="97.1" r="2.1" />
+<circle class="result-objective-proposal" cx="194.6" cy="147.7" r="2.1" />
+<circle class="result-objective-proposal" cx="199.7" cy="147.7" r="2.1" />
+<circle class="result-objective-proposal" cx="204.9" cy="189.9" r="2.1" />
+<circle class="result-objective-proposal" cx="210.0" cy="89.3" r="2.1" />
+<circle class="result-objective-proposal" cx="215.1" cy="198.9" r="2.1" />
+<circle class="result-objective-proposal" cx="220.2" cy="95.7" r="2.1" />
+<circle class="result-objective-proposal" cx="225.3" cy="77.0" r="2.1" />
+<circle class="result-objective-proposal" cx="230.5" cy="89.3" r="2.1" />
+<circle class="result-objective-proposal" cx="235.6" cy="89.3" r="2.1" />
+<circle class="result-objective-proposal" cx="240.7" cy="89.3" r="2.1" />
+<circle class="result-objective-proposal" cx="245.8" cy="151.4" r="2.1" />
+<circle class="result-objective-proposal" cx="250.9" cy="157.7" r="2.1" />
+<circle class="result-objective-proposal" cx="256.0" cy="89.3" r="2.1" />
+<circle class="result-objective-proposal" cx="261.2" cy="89.3" r="2.1" />
+<circle class="result-objective-proposal" cx="266.3" cy="97.1" r="2.1" />
+<circle class="result-objective-proposal" cx="271.4" cy="89.3" r="2.1" />
+<circle class="result-objective-proposal" cx="276.5" cy="185.1" r="2.1" />
+<circle class="result-objective-proposal" cx="281.6" cy="97.1" r="2.1" />
+<circle class="result-objective-proposal" cx="286.8" cy="185.1" r="2.1" />
+<circle class="result-objective-proposal" cx="291.9" cy="218.2" r="2.1" />
+<circle class="result-objective-proposal" cx="297.0" cy="218.2" r="2.1" />
+<circle class="result-objective-proposal" cx="302.1" cy="160.0" r="2.1" />
+<circle class="result-objective-proposal" cx="307.2" cy="157.7" r="2.1" />
+<circle class="result-objective-proposal" cx="312.4" cy="229.6" r="2.1" />
+<circle class="result-objective-proposal" cx="317.5" cy="194.5" r="2.1" />
+<circle class="result-objective-proposal" cx="322.6" cy="198.9" r="2.1" />
+<circle class="result-objective-proposal" cx="327.7" cy="218.2" r="2.1" />
+<circle class="result-objective-proposal" cx="332.8" cy="218.2" r="2.1" />
+<circle class="result-objective-proposal" cx="338.0" cy="194.5" r="2.1" />
+<circle class="result-objective-proposal" cx="343.1" cy="89.3" r="2.1" />
+<circle class="result-objective-proposal" cx="348.2" cy="137.9" r="2.1" />
+<circle class="result-objective-proposal" cx="353.3" cy="196.9" r="2.1" />
+<circle class="result-objective-proposal" cx="358.4" cy="174.9" r="2.1" />
+<circle class="result-objective-proposal" cx="363.5" cy="140.6" r="2.1" />
+<circle class="result-objective-proposal" cx="368.7" cy="97.1" r="2.1" />
+<circle class="result-objective-proposal" cx="373.8" cy="174.9" r="2.1" />
+<circle class="result-objective-proposal" cx="378.9" cy="220.6" r="2.1" />
+<circle class="result-objective-proposal" cx="384.0" cy="151.4" r="2.1" />
+<circle class="result-objective-proposal" cx="389.1" cy="97.1" r="2.1" />
+<circle class="result-objective-proposal" cx="394.3" cy="147.7" r="2.1" />
+<circle class="result-objective-proposal" cx="399.4" cy="147.7" r="2.1" />
+<circle class="result-objective-proposal" cx="404.5" cy="151.4" r="2.1" />
+<circle class="result-objective-proposal" cx="409.6" cy="226.5" r="2.1" />
+<circle class="result-objective-proposal" cx="414.7" cy="89.3" r="2.1" />
+<circle class="result-objective-proposal" cx="419.9" cy="157.7" r="2.1" />
+<circle class="result-objective-proposal" cx="425.0" cy="163.7" r="2.1" />
+<circle class="result-objective-proposal" cx="430.1" cy="147.7" r="2.1" />
+<circle class="result-objective-proposal" cx="435.2" cy="225.0" r="2.1" />
+<circle class="result-objective-proposal" cx="440.3" cy="174.9" r="2.1" />
+<circle class="result-objective-proposal" cx="445.5" cy="157.7" r="2.1" />
+<circle class="result-objective-proposal" cx="450.6" cy="218.2" r="2.1" />
+<circle class="result-objective-proposal" cx="455.7" cy="174.9" r="2.1" />
+<circle class="result-objective-proposal" cx="460.8" cy="151.4" r="2.1" />
+<circle class="result-objective-proposal" cx="465.9" cy="224.6" r="2.1" />
+<circle class="result-objective-proposal" cx="471.0" cy="137.9" r="2.1" />
+<circle class="result-objective-proposal" cx="476.2" cy="151.4" r="2.1" />
+<circle class="result-objective-proposal" cx="481.3" cy="226.5" r="2.1" />
+<circle class="result-objective-proposal" cx="486.4" cy="155.6" r="2.1" />
+<circle class="result-objective-proposal" cx="491.5" cy="163.7" r="2.1" />
+<circle class="result-objective-proposal" cx="496.6" cy="157.7" r="2.1" />
+<circle class="result-objective-proposal" cx="501.8" cy="174.9" r="2.1" />
+<circle class="result-objective-proposal" cx="506.9" cy="137.9" r="2.1" />
+<circle class="result-objective-proposal" cx="512.0" cy="224.6" r="2.1" /></g>
+            <path class="result-objective-best" d="M82.0 77.0 L87.1 77.0 L92.2 97.1 L97.4 97.1 L102.5 97.1 L107.6 104.8 L112.7 104.8 L117.8 104.8 L123.0 174.9 L128.1 174.9 L133.2 174.9 L138.3 174.9 L143.4 174.9 L148.5 174.9 L153.7 174.9 L158.8 174.9 L163.9 174.9 L169.0 174.9 L174.1 174.9 L179.3 174.9 L184.4 174.9 L189.5 174.9 L194.6 174.9 L199.7 174.9 L204.9 189.9 L210.0 189.9 L215.1 198.9 L220.2 198.9 L225.3 198.9 L230.5 198.9 L235.6 198.9 L240.7 198.9 L245.8 198.9 L250.9 198.9 L256.0 198.9 L261.2 198.9 L266.3 198.9 L271.4 198.9 L276.5 198.9 L281.6 198.9 L286.8 198.9 L291.9 218.2 L297.0 218.2 L302.1 218.2 L307.2 218.2 L312.4 229.6 L317.5 229.6 L322.6 229.6 L327.7 229.6 L332.8 229.6 L338.0 229.6 L343.1 229.6 L348.2 229.6 L353.3 229.6 L358.4 229.6 L363.5 229.6 L368.7 229.6 L373.8 229.6 L378.9 229.6 L384.0 229.6 L389.1 229.6 L394.3 229.6 L399.4 229.6 L404.5 229.6 L409.6 229.6 L414.7 229.6 L419.9 229.6 L425.0 229.6 L430.1 229.6 L435.2 229.6 L440.3 229.6 L445.5 229.6 L450.6 229.6 L455.7 229.6 L460.8 229.6 L465.9 229.6 L471.0 229.6 L476.2 229.6 L481.3 229.6 L486.4 229.6 L491.5 229.6 L496.6 229.6 L501.8 229.6 L506.9 229.6 L512.0 229.6" />
+            <g class="result-objective-baseline">
               <circle cx="82.0" cy="77.0" r="4.2" />
             </g>
-            <g class="open-result-objective-accepted">
+            <g class="result-objective-accepted">
               <circle cx="312.4" cy="229.6" r="4.8" />
             </g>
           </svg>
           <figcaption>Figure 6. Objective trace for the curated public chain. Faint points are scored candidates, the solid line is retained best-so-far, and rings mark baseline and accepted.</figcaption>
         </figure>
-<figure class="open-result-paper-table" id="table-2">
-          <div class="open-result-table-wrap">
-            <table class="open-result-table">
+<figure class="result-paper-table" id="table-2">
+          <div class="result-table-wrap">
+            <table class="result-table">
               <thead>
                 <tr>
                   <th>Metric</th>
@@ -646,172 +646,172 @@ p=1.7.
           <figcaption>Table 2. Reported objective comparison under the frozen acceptance contract; lower values are better.</figcaption>
         </figure>
 <p>The residual readout is the numerical check on the objective score. The accepted candidate does not erase every residual; it materially reduces the measured behavior under this contract.</p>
-<figure class="open-result-primer-card open-result-paper-figure" id="fig-7">
-          <svg class="open-result-primer-svg open-result-residual-location-svg open-result-paper-chart-svg" viewBox="0 0 560 456" role="img" aria-label="Residual location diagnostics for the run baseline and accepted rule on each public integrand.">
+<figure class="result-primer-card result-paper-figure" id="fig-7">
+          <svg class="result-primer-svg result-residual-location-svg result-paper-chart-svg" viewBox="0 0 560 456" role="img" aria-label="Residual location diagnostics for the run baseline and accepted rule on each public integrand.">
             <defs>
               <pattern id="acceptedResidualHatch" patternUnits="userSpaceOnUse" width="10" height="10" patternTransform="rotate(62)">
                 <line x1="0" y1="0" x2="0" y2="10" />
               </pattern>
             </defs>
-            <text class="open-result-axis-label open-result-figure-title" x="72" y="34">Residual location diagnostic</text>
-            <g class="open-result-objective-legend" transform="translate(72 48)">
+            <text class="result-axis-label result-figure-title" x="72" y="34">Residual location diagnostic</text>
+            <g class="result-objective-legend" transform="translate(72 48)">
               <g transform="translate(0 0)">
-                <circle class="open-result-legend-baseline-dot" cx="0" cy="0" r="3.4" />
+                <circle class="result-legend-baseline-dot" cx="0" cy="0" r="3.4" />
                 <text x="16" y="4">run baseline sample</text>
               </g>
               <g transform="translate(142 0)">
-                <circle class="open-result-legend-accepted-dot" cx="0" cy="0" r="3.8" />
+                <circle class="result-legend-accepted-dot" cx="0" cy="0" r="3.8" />
                 <text x="16" y="4">accepted samples</text>
               </g>
               <g transform="translate(282 0)">
-                <line class="open-result-objective-legend-best" x1="0" y1="0" x2="18" y2="0" />
+                <line class="result-objective-legend-best" x1="0" y1="0" x2="18" y2="0" />
                 <text x="26" y="4">integrand curve</text>
               </g>
             </g>
             <g transform="translate(0 0)">
-              <text class="open-result-axis-label open-result-figure-title" x="72" y="88">sin(&#960;x)</text>
-              <text class="open-result-axis-label open-result-residual-value" x="414" y="112">run baseline e<tspan baseline-shift="sub" font-size="8">j</tspan></text>
-              <text class="open-result-axis-label open-result-residual-number open-result-residual-number-baseline" x="414" y="131">0.363380</text>
-              <text class="open-result-axis-label open-result-residual-value" x="414" y="156">accepted e<tspan baseline-shift="sub" font-size="8">j</tspan></text>
-              <text class="open-result-axis-label open-result-residual-number" x="414" y="175">0.001029</text>
-              <path class="open-result-primer-grid" d="M72 100 V170 H382" />
-              <text class="open-result-axis-tick" x="72" y="188">0</text>
-              <text class="open-result-axis-tick" x="382" y="188">1</text>
-              <text class="open-result-axis-label open-result-x-axis-title" x="227" y="204">x<tspan baseline-shift="sub" font-size="8">i</tspan></text>
-              <g class="open-result-residual-cell">
+              <text class="result-axis-label result-figure-title" x="72" y="88">sin(&#960;x)</text>
+              <text class="result-axis-label result-residual-value" x="414" y="112">run baseline e<tspan baseline-shift="sub" font-size="8">j</tspan></text>
+              <text class="result-axis-label result-residual-number result-residual-number-baseline" x="414" y="131">0.363380</text>
+              <text class="result-axis-label result-residual-value" x="414" y="156">accepted e<tspan baseline-shift="sub" font-size="8">j</tspan></text>
+              <text class="result-axis-label result-residual-number" x="414" y="175">0.001029</text>
+              <path class="result-primer-grid" d="M72 100 V170 H382" />
+              <text class="result-axis-tick" x="72" y="188">0</text>
+              <text class="result-axis-tick" x="382" y="188">1</text>
+              <text class="result-axis-label result-x-axis-title" x="227" y="204">x<tspan baseline-shift="sub" font-size="8">i</tspan></text>
+              <g class="result-residual-cell">
                 <rect x="72.0" y="153.7" width="62.4" height="16.3" />
-                <path class="open-result-residual-cell-gap-fill" d="M72.0 153.7 L134.4 153.7 L134.4 129.8 L130.7 131.9 L127.1 134.0 L123.4 136.2 L119.7 138.4 L116.0 140.6 L112.4 142.9 L108.7 145.3 L105.0 147.7 L101.4 150.1 L97.7 152.5 L94.0 154.9 L90.4 157.4 L86.7 159.9 L83.0 162.4 L79.3 164.9 L75.7 167.5 L72.0 170.0 Z" />
-                <path class="open-result-residual-cell-gap" d="M72.0 153.7 L134.4 153.7 L134.4 129.8 L130.7 131.9 L127.1 134.0 L123.4 136.2 L119.7 138.4 L116.0 140.6 L112.4 142.9 L108.7 145.3 L105.0 147.7 L101.4 150.1 L97.7 152.5 L94.0 154.9 L90.4 157.4 L86.7 159.9 L83.0 162.4 L79.3 164.9 L75.7 167.5 L72.0 170.0 Z" />
+                <path class="result-residual-cell-gap-fill" d="M72.0 153.7 L134.4 153.7 L134.4 129.8 L130.7 131.9 L127.1 134.0 L123.4 136.2 L119.7 138.4 L116.0 140.6 L112.4 142.9 L108.7 145.3 L105.0 147.7 L101.4 150.1 L97.7 152.5 L94.0 154.9 L90.4 157.4 L86.7 159.9 L83.0 162.4 L79.3 164.9 L75.7 167.5 L72.0 170.0 Z" />
+                <path class="result-residual-cell-gap" d="M72.0 153.7 L134.4 153.7 L134.4 129.8 L130.7 131.9 L127.1 134.0 L123.4 136.2 L119.7 138.4 L116.0 140.6 L112.4 142.9 L108.7 145.3 L105.0 147.7 L101.4 150.1 L97.7 152.5 L94.0 154.9 L90.4 157.4 L86.7 159.9 L83.0 162.4 L79.3 164.9 L75.7 167.5 L72.0 170.0 Z" />
                 <circle cx="95.9" cy="153.7" r="3.2" />
               </g>
-<g class="open-result-residual-cell">
+<g class="result-residual-cell">
                 <rect x="134.4" y="112.0" width="65.5" height="58.0" />
-                <path class="open-result-residual-cell-gap-fill" d="M134.4 112.0 L199.9 112.0 L199.9 104.5 L196.1 105.3 L192.2 106.2 L188.4 107.1 L184.5 108.2 L180.7 109.3 L176.8 110.6 L173.0 111.9 L169.1 113.4 L165.2 114.9 L161.4 116.5 L157.5 118.2 L153.7 119.9 L149.8 121.8 L146.0 123.7 L142.1 125.6 L138.2 127.7 L134.4 129.8 Z" />
-                <path class="open-result-residual-cell-gap" d="M134.4 112.0 L199.9 112.0 L199.9 104.5 L196.1 105.3 L192.2 106.2 L188.4 107.1 L184.5 108.2 L180.7 109.3 L176.8 110.6 L173.0 111.9 L169.1 113.4 L165.2 114.9 L161.4 116.5 L157.5 118.2 L153.7 119.9 L149.8 121.8 L146.0 123.7 L142.1 125.6 L138.2 127.7 L134.4 129.8 Z" />
+                <path class="result-residual-cell-gap-fill" d="M134.4 112.0 L199.9 112.0 L199.9 104.5 L196.1 105.3 L192.2 106.2 L188.4 107.1 L184.5 108.2 L180.7 109.3 L176.8 110.6 L173.0 111.9 L169.1 113.4 L165.2 114.9 L161.4 116.5 L157.5 118.2 L153.7 119.9 L149.8 121.8 L146.0 123.7 L142.1 125.6 L138.2 127.7 L134.4 129.8 Z" />
+                <path class="result-residual-cell-gap" d="M134.4 112.0 L199.9 112.0 L199.9 104.5 L196.1 105.3 L192.2 106.2 L188.4 107.1 L184.5 108.2 L180.7 109.3 L176.8 110.6 L173.0 111.9 L169.1 113.4 L165.2 114.9 L161.4 116.5 L157.5 118.2 L153.7 119.9 L149.8 121.8 L146.0 123.7 L142.1 125.6 L138.2 127.7 L134.4 129.8 Z" />
                 <circle cx="172.9" cy="112.0" r="3.2" />
               </g>
-<g class="open-result-residual-cell">
+<g class="result-residual-cell">
                 <rect x="199.9" y="102.0" width="54.1" height="68.0" />
-                <path class="open-result-residual-cell-gap-fill" d="M199.9 102.0 L254.1 102.0 L254.1 104.5 L250.9 104.0 L247.7 103.5 L244.5 103.1 L241.3 102.7 L238.1 102.4 L235.0 102.2 L231.8 102.1 L228.6 102.0 L225.4 102.0 L222.2 102.1 L219.0 102.2 L215.9 102.4 L212.7 102.7 L209.5 103.1 L206.3 103.5 L203.1 104.0 L199.9 104.5 Z" />
-                <path class="open-result-residual-cell-gap" d="M199.9 102.0 L254.1 102.0 L254.1 104.5 L250.9 104.0 L247.7 103.5 L244.5 103.1 L241.3 102.7 L238.1 102.4 L235.0 102.2 L231.8 102.1 L228.6 102.0 L225.4 102.0 L222.2 102.1 L219.0 102.2 L215.9 102.4 L212.7 102.7 L209.5 103.1 L206.3 103.5 L203.1 104.0 L199.9 104.5 Z" />
+                <path class="result-residual-cell-gap-fill" d="M199.9 102.0 L254.1 102.0 L254.1 104.5 L250.9 104.0 L247.7 103.5 L244.5 103.1 L241.3 102.7 L238.1 102.4 L235.0 102.2 L231.8 102.1 L228.6 102.0 L225.4 102.0 L222.2 102.1 L219.0 102.2 L215.9 102.4 L212.7 102.7 L209.5 103.1 L206.3 103.5 L203.1 104.0 L199.9 104.5 Z" />
+                <path class="result-residual-cell-gap" d="M199.9 102.0 L254.1 102.0 L254.1 104.5 L250.9 104.0 L247.7 103.5 L244.5 103.1 L241.3 102.7 L238.1 102.4 L235.0 102.2 L231.8 102.1 L228.6 102.0 L225.4 102.0 L222.2 102.1 L219.0 102.2 L215.9 102.4 L212.7 102.7 L209.5 103.1 L206.3 103.5 L203.1 104.0 L199.9 104.5 Z" />
                 <circle cx="227.0" cy="102.0" r="3.2" />
               </g>
-<g class="open-result-residual-cell">
+<g class="result-residual-cell">
                 <rect x="254.1" y="112.0" width="65.5" height="58.0" />
-                <path class="open-result-residual-cell-gap-fill" d="M254.1 112.0 L319.6 112.0 L319.6 129.8 L315.8 127.7 L311.9 125.6 L308.0 123.7 L304.2 121.8 L300.3 119.9 L296.5 118.2 L292.6 116.5 L288.8 114.9 L284.9 113.4 L281.0 111.9 L277.2 110.6 L273.3 109.3 L269.5 108.2 L265.6 107.1 L261.8 106.2 L257.9 105.3 L254.1 104.5 Z" />
-                <path class="open-result-residual-cell-gap" d="M254.1 112.0 L319.6 112.0 L319.6 129.8 L315.8 127.7 L311.9 125.6 L308.0 123.7 L304.2 121.8 L300.3 119.9 L296.5 118.2 L292.6 116.5 L288.8 114.9 L284.9 113.4 L281.0 111.9 L277.2 110.6 L273.3 109.3 L269.5 108.2 L265.6 107.1 L261.8 106.2 L257.9 105.3 L254.1 104.5 Z" />
+                <path class="result-residual-cell-gap-fill" d="M254.1 112.0 L319.6 112.0 L319.6 129.8 L315.8 127.7 L311.9 125.6 L308.0 123.7 L304.2 121.8 L300.3 119.9 L296.5 118.2 L292.6 116.5 L288.8 114.9 L284.9 113.4 L281.0 111.9 L277.2 110.6 L273.3 109.3 L269.5 108.2 L265.6 107.1 L261.8 106.2 L257.9 105.3 L254.1 104.5 Z" />
+                <path class="result-residual-cell-gap" d="M254.1 112.0 L319.6 112.0 L319.6 129.8 L315.8 127.7 L311.9 125.6 L308.0 123.7 L304.2 121.8 L300.3 119.9 L296.5 118.2 L292.6 116.5 L288.8 114.9 L284.9 113.4 L281.0 111.9 L277.2 110.6 L273.3 109.3 L269.5 108.2 L265.6 107.1 L261.8 106.2 L257.9 105.3 L254.1 104.5 Z" />
                 <circle cx="281.1" cy="112.0" r="3.2" />
               </g>
-<g class="open-result-residual-cell">
+<g class="result-residual-cell">
                 <rect x="319.6" y="153.7" width="62.4" height="16.3" />
-                <path class="open-result-residual-cell-gap-fill" d="M319.6 153.7 L382.0 153.7 L382.0 170.0 L378.3 167.5 L374.7 164.9 L371.0 162.4 L367.3 159.9 L363.6 157.4 L360.0 154.9 L356.3 152.5 L352.6 150.1 L349.0 147.7 L345.3 145.3 L341.6 142.9 L338.0 140.6 L334.3 138.4 L330.6 136.2 L326.9 134.0 L323.3 131.9 L319.6 129.8 Z" />
-                <path class="open-result-residual-cell-gap" d="M319.6 153.7 L382.0 153.7 L382.0 170.0 L378.3 167.5 L374.7 164.9 L371.0 162.4 L367.3 159.9 L363.6 157.4 L360.0 154.9 L356.3 152.5 L352.6 150.1 L349.0 147.7 L345.3 145.3 L341.6 142.9 L338.0 140.6 L334.3 138.4 L330.6 136.2 L326.9 134.0 L323.3 131.9 L319.6 129.8 Z" />
+                <path class="result-residual-cell-gap-fill" d="M319.6 153.7 L382.0 153.7 L382.0 170.0 L378.3 167.5 L374.7 164.9 L371.0 162.4 L367.3 159.9 L363.6 157.4 L360.0 154.9 L356.3 152.5 L352.6 150.1 L349.0 147.7 L345.3 145.3 L341.6 142.9 L338.0 140.6 L334.3 138.4 L330.6 136.2 L326.9 134.0 L323.3 131.9 L319.6 129.8 Z" />
+                <path class="result-residual-cell-gap" d="M319.6 153.7 L382.0 153.7 L382.0 170.0 L378.3 167.5 L374.7 164.9 L371.0 162.4 L367.3 159.9 L363.6 157.4 L360.0 154.9 L356.3 152.5 L352.6 150.1 L349.0 147.7 L345.3 145.3 L341.6 142.9 L338.0 140.6 L334.3 138.4 L330.6 136.2 L326.9 134.0 L323.3 131.9 L319.6 129.8 Z" />
                 <circle cx="358.1" cy="153.7" r="3.2" />
               </g>
-              <g class="open-result-residual-baseline-marker">
+              <g class="result-residual-baseline-marker">
                 <line x1="227.0" y1="170" x2="227.0" y2="102.0" />
                 <circle cx="227.0" cy="102.0" r="3.6" />
               </g>
-              <path class="open-result-primer-curve" d="M72.0 170.0 L75.5 167.6 L79.0 165.2 L82.4 162.8 L85.9 160.4 L89.4 158.1 L92.9 155.7 L96.4 153.4 L99.9 151.0 L103.3 148.8 L106.8 146.5 L110.3 144.2 L113.8 142.0 L117.3 139.9 L120.8 137.7 L124.2 135.6 L127.7 133.6 L131.2 131.6 L134.7 129.6 L138.2 127.7 L141.7 125.9 L145.1 124.1 L148.6 122.3 L152.1 120.7 L155.6 119.0 L159.1 117.5 L162.6 116.0 L166.0 114.6 L169.5 113.2 L173.0 111.9 L176.5 110.7 L180.0 109.6 L183.5 108.5 L186.9 107.5 L190.4 106.6 L193.9 105.8 L197.4 105.0 L200.9 104.4 L204.4 103.8 L207.8 103.3 L211.3 102.8 L214.8 102.5 L218.3 102.3 L221.8 102.1 L225.3 102.0 L228.7 102.0 L232.2 102.1 L235.7 102.3 L239.2 102.5 L242.7 102.8 L246.2 103.3 L249.6 103.8 L253.1 104.4 L256.6 105.0 L260.1 105.8 L263.6 106.6 L267.1 107.5 L270.5 108.5 L274.0 109.6 L277.5 110.7 L281.0 111.9 L284.5 113.2 L288.0 114.6 L291.4 116.0 L294.9 117.5 L298.4 119.0 L301.9 120.7 L305.4 122.3 L308.9 124.1 L312.3 125.9 L315.8 127.7 L319.3 129.6 L322.8 131.6 L326.3 133.6 L329.8 135.6 L333.2 137.7 L336.7 139.9 L340.2 142.0 L343.7 144.2 L347.2 146.5 L350.7 148.8 L354.1 151.0 L357.6 153.4 L361.1 155.7 L364.6 158.1 L368.1 160.4 L371.6 162.8 L375.0 165.2 L378.5 167.6 L382.0 170.0" />
+              <path class="result-primer-curve" d="M72.0 170.0 L75.5 167.6 L79.0 165.2 L82.4 162.8 L85.9 160.4 L89.4 158.1 L92.9 155.7 L96.4 153.4 L99.9 151.0 L103.3 148.8 L106.8 146.5 L110.3 144.2 L113.8 142.0 L117.3 139.9 L120.8 137.7 L124.2 135.6 L127.7 133.6 L131.2 131.6 L134.7 129.6 L138.2 127.7 L141.7 125.9 L145.1 124.1 L148.6 122.3 L152.1 120.7 L155.6 119.0 L159.1 117.5 L162.6 116.0 L166.0 114.6 L169.5 113.2 L173.0 111.9 L176.5 110.7 L180.0 109.6 L183.5 108.5 L186.9 107.5 L190.4 106.6 L193.9 105.8 L197.4 105.0 L200.9 104.4 L204.4 103.8 L207.8 103.3 L211.3 102.8 L214.8 102.5 L218.3 102.3 L221.8 102.1 L225.3 102.0 L228.7 102.0 L232.2 102.1 L235.7 102.3 L239.2 102.5 L242.7 102.8 L246.2 103.3 L249.6 103.8 L253.1 104.4 L256.6 105.0 L260.1 105.8 L263.6 106.6 L267.1 107.5 L270.5 108.5 L274.0 109.6 L277.5 110.7 L281.0 111.9 L284.5 113.2 L288.0 114.6 L291.4 116.0 L294.9 117.5 L298.4 119.0 L301.9 120.7 L305.4 122.3 L308.9 124.1 L312.3 125.9 L315.8 127.7 L319.3 129.6 L322.8 131.6 L326.3 133.6 L329.8 135.6 L333.2 137.7 L336.7 139.9 L340.2 142.0 L343.7 144.2 L347.2 146.5 L350.7 148.8 L354.1 151.0 L357.6 153.4 L361.1 155.7 L364.6 158.1 L368.1 160.4 L371.6 162.8 L375.0 165.2 L378.5 167.6 L382.0 170.0" />
             </g>
 <g transform="translate(0 0)">
-              <text class="open-result-axis-label open-result-figure-title" x="72" y="204">&#8730;x</text>
-              <text class="open-result-axis-label open-result-residual-value" x="414" y="228">run baseline e<tspan baseline-shift="sub" font-size="8">j</tspan></text>
-              <text class="open-result-axis-label open-result-residual-number open-result-residual-number-baseline" x="414" y="247">0.040440</text>
-              <text class="open-result-axis-label open-result-residual-value" x="414" y="272">accepted e<tspan baseline-shift="sub" font-size="8">j</tspan></text>
-              <text class="open-result-axis-label open-result-residual-number" x="414" y="291">0.000614</text>
-              <path class="open-result-primer-grid" d="M72 216 V286 H382" />
-              <text class="open-result-axis-tick" x="72" y="304">0</text>
-              <text class="open-result-axis-tick" x="382" y="304">1</text>
-              <text class="open-result-axis-label open-result-x-axis-title" x="227" y="320">x<tspan baseline-shift="sub" font-size="8">i</tspan></text>
-              <g class="open-result-residual-cell">
+              <text class="result-axis-label result-figure-title" x="72" y="204">&#8730;x</text>
+              <text class="result-axis-label result-residual-value" x="414" y="228">run baseline e<tspan baseline-shift="sub" font-size="8">j</tspan></text>
+              <text class="result-axis-label result-residual-number result-residual-number-baseline" x="414" y="247">0.040440</text>
+              <text class="result-axis-label result-residual-value" x="414" y="272">accepted e<tspan baseline-shift="sub" font-size="8">j</tspan></text>
+              <text class="result-axis-label result-residual-number" x="414" y="291">0.000614</text>
+              <path class="result-primer-grid" d="M72 216 V286 H382" />
+              <text class="result-axis-tick" x="72" y="304">0</text>
+              <text class="result-axis-tick" x="382" y="304">1</text>
+              <text class="result-axis-label result-x-axis-title" x="227" y="320">x<tspan baseline-shift="sub" font-size="8">i</tspan></text>
+              <g class="result-residual-cell">
                 <rect x="72.0" y="267.1" width="62.4" height="18.9" />
-                <path class="open-result-residual-cell-gap-fill" d="M72.0 267.1 L134.4 267.1 L134.4 255.5 L130.7 256.4 L127.1 257.3 L123.4 258.3 L119.7 259.3 L116.0 260.4 L112.4 261.5 L108.7 262.6 L105.0 263.8 L101.4 265.1 L97.7 266.4 L94.0 267.9 L90.4 269.5 L86.7 271.2 L83.0 273.2 L79.3 275.5 L75.7 278.6 L72.0 286.0 Z" />
-                <path class="open-result-residual-cell-gap" d="M72.0 267.1 L134.4 267.1 L134.4 255.5 L130.7 256.4 L127.1 257.3 L123.4 258.3 L119.7 259.3 L116.0 260.4 L112.4 261.5 L108.7 262.6 L105.0 263.8 L101.4 265.1 L97.7 266.4 L94.0 267.9 L90.4 269.5 L86.7 271.2 L83.0 273.2 L79.3 275.5 L75.7 278.6 L72.0 286.0 Z" />
+                <path class="result-residual-cell-gap-fill" d="M72.0 267.1 L134.4 267.1 L134.4 255.5 L130.7 256.4 L127.1 257.3 L123.4 258.3 L119.7 259.3 L116.0 260.4 L112.4 261.5 L108.7 262.6 L105.0 263.8 L101.4 265.1 L97.7 266.4 L94.0 267.9 L90.4 269.5 L86.7 271.2 L83.0 273.2 L79.3 275.5 L75.7 278.6 L72.0 286.0 Z" />
+                <path class="result-residual-cell-gap" d="M72.0 267.1 L134.4 267.1 L134.4 255.5 L130.7 256.4 L127.1 257.3 L123.4 258.3 L119.7 259.3 L116.0 260.4 L112.4 261.5 L108.7 262.6 L105.0 263.8 L101.4 265.1 L97.7 266.4 L94.0 267.9 L90.4 269.5 L86.7 271.2 L83.0 273.2 L79.3 275.5 L75.7 278.6 L72.0 286.0 Z" />
                 <circle cx="95.9" cy="267.1" r="3.2" />
               </g>
-<g class="open-result-residual-cell">
+<g class="result-residual-cell">
                 <rect x="134.4" y="247.2" width="65.5" height="38.8" />
-                <path class="open-result-residual-cell-gap-fill" d="M134.4 247.2 L199.9 247.2 L199.9 242.3 L196.1 243.0 L192.2 243.7 L188.4 244.3 L184.5 245.0 L180.7 245.7 L176.8 246.5 L173.0 247.2 L169.1 247.9 L165.2 248.7 L161.4 249.5 L157.5 250.3 L153.7 251.1 L149.8 251.9 L146.0 252.8 L142.1 253.7 L138.2 254.6 L134.4 255.5 Z" />
-                <path class="open-result-residual-cell-gap" d="M134.4 247.2 L199.9 247.2 L199.9 242.3 L196.1 243.0 L192.2 243.7 L188.4 244.3 L184.5 245.0 L180.7 245.7 L176.8 246.5 L173.0 247.2 L169.1 247.9 L165.2 248.7 L161.4 249.5 L157.5 250.3 L153.7 251.1 L149.8 251.9 L146.0 252.8 L142.1 253.7 L138.2 254.6 L134.4 255.5 Z" />
+                <path class="result-residual-cell-gap-fill" d="M134.4 247.2 L199.9 247.2 L199.9 242.3 L196.1 243.0 L192.2 243.7 L188.4 244.3 L184.5 245.0 L180.7 245.7 L176.8 246.5 L173.0 247.2 L169.1 247.9 L165.2 248.7 L161.4 249.5 L157.5 250.3 L153.7 251.1 L149.8 251.9 L146.0 252.8 L142.1 253.7 L138.2 254.6 L134.4 255.5 Z" />
+                <path class="result-residual-cell-gap" d="M134.4 247.2 L199.9 247.2 L199.9 242.3 L196.1 243.0 L192.2 243.7 L188.4 244.3 L184.5 245.0 L180.7 245.7 L176.8 246.5 L173.0 247.2 L169.1 247.9 L165.2 248.7 L161.4 249.5 L157.5 250.3 L153.7 251.1 L149.8 251.9 L146.0 252.8 L142.1 253.7 L138.2 254.6 L134.4 255.5 Z" />
                 <circle cx="172.9" cy="247.2" r="3.2" />
               </g>
-<g class="open-result-residual-cell">
+<g class="result-residual-cell">
                 <rect x="199.9" y="237.9" width="54.1" height="48.1" />
-                <path class="open-result-residual-cell-gap-fill" d="M199.9 237.9 L254.1 237.9 L254.1 233.9 L250.9 234.3 L247.7 234.8 L244.5 235.3 L241.3 235.7 L238.1 236.2 L235.0 236.7 L231.8 237.2 L228.6 237.7 L225.4 238.2 L222.2 238.7 L219.0 239.2 L215.9 239.7 L212.7 240.2 L209.5 240.7 L206.3 241.2 L203.1 241.8 L199.9 242.3 Z" />
-                <path class="open-result-residual-cell-gap" d="M199.9 237.9 L254.1 237.9 L254.1 233.9 L250.9 234.3 L247.7 234.8 L244.5 235.3 L241.3 235.7 L238.1 236.2 L235.0 236.7 L231.8 237.2 L228.6 237.7 L225.4 238.2 L222.2 238.7 L219.0 239.2 L215.9 239.7 L212.7 240.2 L209.5 240.7 L206.3 241.2 L203.1 241.8 L199.9 242.3 Z" />
+                <path class="result-residual-cell-gap-fill" d="M199.9 237.9 L254.1 237.9 L254.1 233.9 L250.9 234.3 L247.7 234.8 L244.5 235.3 L241.3 235.7 L238.1 236.2 L235.0 236.7 L231.8 237.2 L228.6 237.7 L225.4 238.2 L222.2 238.7 L219.0 239.2 L215.9 239.7 L212.7 240.2 L209.5 240.7 L206.3 241.2 L203.1 241.8 L199.9 242.3 Z" />
+                <path class="result-residual-cell-gap" d="M199.9 237.9 L254.1 237.9 L254.1 233.9 L250.9 234.3 L247.7 234.8 L244.5 235.3 L241.3 235.7 L238.1 236.2 L235.0 236.7 L231.8 237.2 L228.6 237.7 L225.4 238.2 L222.2 238.7 L219.0 239.2 L215.9 239.7 L212.7 240.2 L209.5 240.7 L206.3 241.2 L203.1 241.8 L199.9 242.3 Z" />
                 <circle cx="227.0" cy="237.9" r="3.2" />
               </g>
-<g class="open-result-residual-cell">
+<g class="result-residual-cell">
                 <rect x="254.1" y="230.2" width="65.5" height="55.8" />
-                <path class="open-result-residual-cell-gap-fill" d="M254.1 230.2 L319.6 230.2 L319.6 225.2 L315.8 225.7 L311.9 226.2 L308.0 226.7 L304.2 227.2 L300.3 227.6 L296.5 228.1 L292.6 228.6 L288.8 229.1 L284.9 229.6 L281.0 230.2 L277.2 230.7 L273.3 231.2 L269.5 231.7 L265.6 232.3 L261.8 232.8 L257.9 233.3 L254.1 233.9 Z" />
-                <path class="open-result-residual-cell-gap" d="M254.1 230.2 L319.6 230.2 L319.6 225.2 L315.8 225.7 L311.9 226.2 L308.0 226.7 L304.2 227.2 L300.3 227.6 L296.5 228.1 L292.6 228.6 L288.8 229.1 L284.9 229.6 L281.0 230.2 L277.2 230.7 L273.3 231.2 L269.5 231.7 L265.6 232.3 L261.8 232.8 L257.9 233.3 L254.1 233.9 Z" />
+                <path class="result-residual-cell-gap-fill" d="M254.1 230.2 L319.6 230.2 L319.6 225.2 L315.8 225.7 L311.9 226.2 L308.0 226.7 L304.2 227.2 L300.3 227.6 L296.5 228.1 L292.6 228.6 L288.8 229.1 L284.9 229.6 L281.0 230.2 L277.2 230.7 L273.3 231.2 L269.5 231.7 L265.6 232.3 L261.8 232.8 L257.9 233.3 L254.1 233.9 Z" />
+                <path class="result-residual-cell-gap" d="M254.1 230.2 L319.6 230.2 L319.6 225.2 L315.8 225.7 L311.9 226.2 L308.0 226.7 L304.2 227.2 L300.3 227.6 L296.5 228.1 L292.6 228.6 L288.8 229.1 L284.9 229.6 L281.0 230.2 L277.2 230.7 L273.3 231.2 L269.5 231.7 L265.6 232.3 L261.8 232.8 L257.9 233.3 L254.1 233.9 Z" />
                 <circle cx="281.1" cy="230.2" r="3.2" />
               </g>
-<g class="open-result-residual-cell">
+<g class="result-residual-cell">
                 <rect x="319.6" y="220.7" width="62.4" height="65.3" />
-                <path class="open-result-residual-cell-gap-fill" d="M319.6 220.7 L382.0 220.7 L382.0 218.0 L378.3 218.4 L374.7 218.8 L371.0 219.2 L367.3 219.6 L363.6 220.0 L360.0 220.5 L356.3 220.9 L352.6 221.3 L349.0 221.7 L345.3 222.2 L341.6 222.6 L338.0 223.0 L334.3 223.5 L330.6 223.9 L326.9 224.3 L323.3 224.8 L319.6 225.2 Z" />
-                <path class="open-result-residual-cell-gap" d="M319.6 220.7 L382.0 220.7 L382.0 218.0 L378.3 218.4 L374.7 218.8 L371.0 219.2 L367.3 219.6 L363.6 220.0 L360.0 220.5 L356.3 220.9 L352.6 221.3 L349.0 221.7 L345.3 222.2 L341.6 222.6 L338.0 223.0 L334.3 223.5 L330.6 223.9 L326.9 224.3 L323.3 224.8 L319.6 225.2 Z" />
+                <path class="result-residual-cell-gap-fill" d="M319.6 220.7 L382.0 220.7 L382.0 218.0 L378.3 218.4 L374.7 218.8 L371.0 219.2 L367.3 219.6 L363.6 220.0 L360.0 220.5 L356.3 220.9 L352.6 221.3 L349.0 221.7 L345.3 222.2 L341.6 222.6 L338.0 223.0 L334.3 223.5 L330.6 223.9 L326.9 224.3 L323.3 224.8 L319.6 225.2 Z" />
+                <path class="result-residual-cell-gap" d="M319.6 220.7 L382.0 220.7 L382.0 218.0 L378.3 218.4 L374.7 218.8 L371.0 219.2 L367.3 219.6 L363.6 220.0 L360.0 220.5 L356.3 220.9 L352.6 221.3 L349.0 221.7 L345.3 222.2 L341.6 222.6 L338.0 223.0 L334.3 223.5 L330.6 223.9 L326.9 224.3 L323.3 224.8 L319.6 225.2 Z" />
                 <circle cx="358.1" cy="220.7" r="3.2" />
               </g>
-              <g class="open-result-residual-baseline-marker">
+              <g class="result-residual-baseline-marker">
                 <line x1="227.0" y1="286" x2="227.0" y2="237.9" />
                 <circle cx="227.0" cy="237.9" r="3.6" />
               </g>
-              <path class="open-result-primer-curve" d="M72.0 286.0 L75.5 278.8 L79.0 275.8 L82.4 273.5 L85.9 271.6 L89.4 269.9 L92.9 268.3 L96.4 266.9 L99.9 265.6 L103.3 264.4 L106.8 263.2 L110.3 262.1 L113.8 261.0 L117.3 260.0 L120.8 259.0 L124.2 258.1 L127.7 257.2 L131.2 256.3 L134.7 255.4 L138.2 254.6 L141.7 253.8 L145.1 253.0 L148.6 252.2 L152.1 251.4 L155.6 250.7 L159.1 250.0 L162.6 249.2 L166.0 248.5 L169.5 247.9 L173.0 247.2 L176.5 246.5 L180.0 245.9 L183.5 245.2 L186.9 244.6 L190.4 244.0 L193.9 243.4 L197.4 242.8 L200.9 242.2 L204.4 241.6 L207.8 241.0 L211.3 240.4 L214.8 239.8 L218.3 239.3 L221.8 238.7 L225.3 238.2 L228.7 237.6 L232.2 237.1 L235.7 236.6 L239.2 236.1 L242.7 235.5 L246.2 235.0 L249.6 234.5 L253.1 234.0 L256.6 233.5 L260.1 233.0 L263.6 232.5 L267.1 232.1 L270.5 231.6 L274.0 231.1 L277.5 230.6 L281.0 230.2 L284.5 229.7 L288.0 229.2 L291.4 228.8 L294.9 228.3 L298.4 227.9 L301.9 227.4 L305.4 227.0 L308.9 226.6 L312.3 226.1 L315.8 225.7 L319.3 225.3 L322.8 224.8 L326.3 224.4 L329.8 224.0 L333.2 223.6 L336.7 223.2 L340.2 222.8 L343.7 222.3 L347.2 221.9 L350.7 221.5 L354.1 221.1 L357.6 220.7 L361.1 220.3 L364.6 219.9 L368.1 219.5 L371.6 219.2 L375.0 218.8 L378.5 218.4 L382.0 218.0" />
+              <path class="result-primer-curve" d="M72.0 286.0 L75.5 278.8 L79.0 275.8 L82.4 273.5 L85.9 271.6 L89.4 269.9 L92.9 268.3 L96.4 266.9 L99.9 265.6 L103.3 264.4 L106.8 263.2 L110.3 262.1 L113.8 261.0 L117.3 260.0 L120.8 259.0 L124.2 258.1 L127.7 257.2 L131.2 256.3 L134.7 255.4 L138.2 254.6 L141.7 253.8 L145.1 253.0 L148.6 252.2 L152.1 251.4 L155.6 250.7 L159.1 250.0 L162.6 249.2 L166.0 248.5 L169.5 247.9 L173.0 247.2 L176.5 246.5 L180.0 245.9 L183.5 245.2 L186.9 244.6 L190.4 244.0 L193.9 243.4 L197.4 242.8 L200.9 242.2 L204.4 241.6 L207.8 241.0 L211.3 240.4 L214.8 239.8 L218.3 239.3 L221.8 238.7 L225.3 238.2 L228.7 237.6 L232.2 237.1 L235.7 236.6 L239.2 236.1 L242.7 235.5 L246.2 235.0 L249.6 234.5 L253.1 234.0 L256.6 233.5 L260.1 233.0 L263.6 232.5 L267.1 232.1 L270.5 231.6 L274.0 231.1 L277.5 230.6 L281.0 230.2 L284.5 229.7 L288.0 229.2 L291.4 228.8 L294.9 228.3 L298.4 227.9 L301.9 227.4 L305.4 227.0 L308.9 226.6 L312.3 226.1 L315.8 225.7 L319.3 225.3 L322.8 224.8 L326.3 224.4 L329.8 224.0 L333.2 223.6 L336.7 223.2 L340.2 222.8 L343.7 222.3 L347.2 221.9 L350.7 221.5 L354.1 221.1 L357.6 220.7 L361.1 220.3 L364.6 219.9 L368.1 219.5 L371.6 219.2 L375.0 218.8 L378.5 218.4 L382.0 218.0" />
             </g>
 <g transform="translate(0 0)">
-              <text class="open-result-axis-label open-result-figure-title" x="72" y="320">log(1+x)</text>
-              <text class="open-result-axis-label open-result-residual-value" x="414" y="344">run baseline e<tspan baseline-shift="sub" font-size="8">j</tspan></text>
-              <text class="open-result-axis-label open-result-residual-number open-result-residual-number-baseline" x="414" y="363">0.019171</text>
-              <text class="open-result-axis-label open-result-residual-value" x="414" y="388">accepted e<tspan baseline-shift="sub" font-size="8">j</tspan></text>
-              <text class="open-result-axis-label open-result-residual-number" x="414" y="407">0.000282</text>
-              <path class="open-result-primer-grid" d="M72 332 V402 H382" />
-              <text class="open-result-axis-tick" x="72" y="420">0</text>
-              <text class="open-result-axis-tick" x="382" y="420">1</text>
-              <text class="open-result-axis-label open-result-x-axis-title" x="227" y="436">x<tspan baseline-shift="sub" font-size="8">i</tspan></text>
-              <g class="open-result-residual-cell">
+              <text class="result-axis-label result-figure-title" x="72" y="320">log(1+x)</text>
+              <text class="result-axis-label result-residual-value" x="414" y="344">run baseline e<tspan baseline-shift="sub" font-size="8">j</tspan></text>
+              <text class="result-axis-label result-residual-number result-residual-number-baseline" x="414" y="363">0.019171</text>
+              <text class="result-axis-label result-residual-value" x="414" y="388">accepted e<tspan baseline-shift="sub" font-size="8">j</tspan></text>
+              <text class="result-axis-label result-residual-number" x="414" y="407">0.000282</text>
+              <path class="result-primer-grid" d="M72 332 V402 H382" />
+              <text class="result-axis-tick" x="72" y="420">0</text>
+              <text class="result-axis-tick" x="382" y="420">1</text>
+              <text class="result-axis-label result-x-axis-title" x="227" y="436">x<tspan baseline-shift="sub" font-size="8">i</tspan></text>
+              <g class="result-residual-cell">
                 <rect x="72.0" y="394.7" width="62.4" height="7.3" />
-                <path class="open-result-residual-cell-gap-fill" d="M72.0 394.7 L134.4 394.7 L134.4 384.0 L130.7 385.0 L127.1 386.0 L123.4 387.0 L119.7 388.0 L116.0 389.0 L112.4 390.0 L108.7 391.0 L105.0 392.1 L101.4 393.1 L97.7 394.2 L94.0 395.3 L90.4 396.4 L86.7 397.5 L83.0 398.6 L79.3 399.7 L75.7 400.8 L72.0 402.0 Z" />
-                <path class="open-result-residual-cell-gap" d="M72.0 394.7 L134.4 394.7 L134.4 384.0 L130.7 385.0 L127.1 386.0 L123.4 387.0 L119.7 388.0 L116.0 389.0 L112.4 390.0 L108.7 391.0 L105.0 392.1 L101.4 393.1 L97.7 394.2 L94.0 395.3 L90.4 396.4 L86.7 397.5 L83.0 398.6 L79.3 399.7 L75.7 400.8 L72.0 402.0 Z" />
+                <path class="result-residual-cell-gap-fill" d="M72.0 394.7 L134.4 394.7 L134.4 384.0 L130.7 385.0 L127.1 386.0 L123.4 387.0 L119.7 388.0 L116.0 389.0 L112.4 390.0 L108.7 391.0 L105.0 392.1 L101.4 393.1 L97.7 394.2 L94.0 395.3 L90.4 396.4 L86.7 397.5 L83.0 398.6 L79.3 399.7 L75.7 400.8 L72.0 402.0 Z" />
+                <path class="result-residual-cell-gap" d="M72.0 394.7 L134.4 394.7 L134.4 384.0 L130.7 385.0 L127.1 386.0 L123.4 387.0 L119.7 388.0 L116.0 389.0 L112.4 390.0 L108.7 391.0 L105.0 392.1 L101.4 393.1 L97.7 394.2 L94.0 395.3 L90.4 396.4 L86.7 397.5 L83.0 398.6 L79.3 399.7 L75.7 400.8 L72.0 402.0 Z" />
                 <circle cx="95.9" cy="394.7" r="3.2" />
               </g>
-<g class="open-result-residual-cell">
+<g class="result-residual-cell">
                 <rect x="134.4" y="374.4" width="65.5" height="27.6" />
-                <path class="open-result-residual-cell-gap-fill" d="M134.4 374.4 L199.9 374.4 L199.9 368.1 L196.1 369.0 L192.2 369.8 L188.4 370.7 L184.5 371.6 L180.7 372.5 L176.8 373.4 L173.0 374.3 L169.1 375.3 L165.2 376.2 L161.4 377.1 L157.5 378.1 L153.7 379.1 L149.8 380.0 L146.0 381.0 L142.1 382.0 L138.2 383.0 L134.4 384.0 Z" />
-                <path class="open-result-residual-cell-gap" d="M134.4 374.4 L199.9 374.4 L199.9 368.1 L196.1 369.0 L192.2 369.8 L188.4 370.7 L184.5 371.6 L180.7 372.5 L176.8 373.4 L173.0 374.3 L169.1 375.3 L165.2 376.2 L161.4 377.1 L157.5 378.1 L153.7 379.1 L149.8 380.0 L146.0 381.0 L142.1 382.0 L138.2 383.0 L134.4 384.0 Z" />
+                <path class="result-residual-cell-gap-fill" d="M134.4 374.4 L199.9 374.4 L199.9 368.1 L196.1 369.0 L192.2 369.8 L188.4 370.7 L184.5 371.6 L180.7 372.5 L176.8 373.4 L173.0 374.3 L169.1 375.3 L165.2 376.2 L161.4 377.1 L157.5 378.1 L153.7 379.1 L149.8 380.0 L146.0 381.0 L142.1 382.0 L138.2 383.0 L134.4 384.0 Z" />
+                <path class="result-residual-cell-gap" d="M134.4 374.4 L199.9 374.4 L199.9 368.1 L196.1 369.0 L192.2 369.8 L188.4 370.7 L184.5 371.6 L180.7 372.5 L176.8 373.4 L173.0 374.3 L169.1 375.3 L165.2 376.2 L161.4 377.1 L157.5 378.1 L153.7 379.1 L149.8 380.0 L146.0 381.0 L142.1 382.0 L138.2 383.0 L134.4 384.0 Z" />
                 <circle cx="172.9" cy="374.4" r="3.2" />
               </g>
-<g class="open-result-residual-cell">
+<g class="result-residual-cell">
                 <rect x="199.9" y="362.2" width="54.1" height="39.8" />
-                <path class="open-result-residual-cell-gap-fill" d="M199.9 362.2 L254.1 362.2 L254.1 356.7 L250.9 357.3 L247.7 358.0 L244.5 358.6 L241.3 359.2 L238.1 359.9 L235.0 360.6 L231.8 361.2 L228.6 361.9 L225.4 362.6 L222.2 363.2 L219.0 363.9 L215.9 364.6 L212.7 365.3 L209.5 366.0 L206.3 366.7 L203.1 367.4 L199.9 368.1 Z" />
-                <path class="open-result-residual-cell-gap" d="M199.9 362.2 L254.1 362.2 L254.1 356.7 L250.9 357.3 L247.7 358.0 L244.5 358.6 L241.3 359.2 L238.1 359.9 L235.0 360.6 L231.8 361.2 L228.6 361.9 L225.4 362.6 L222.2 363.2 L219.0 363.9 L215.9 364.6 L212.7 365.3 L209.5 366.0 L206.3 366.7 L203.1 367.4 L199.9 368.1 Z" />
+                <path class="result-residual-cell-gap-fill" d="M199.9 362.2 L254.1 362.2 L254.1 356.7 L250.9 357.3 L247.7 358.0 L244.5 358.6 L241.3 359.2 L238.1 359.9 L235.0 360.6 L231.8 361.2 L228.6 361.9 L225.4 362.6 L222.2 363.2 L219.0 363.9 L215.9 364.6 L212.7 365.3 L209.5 366.0 L206.3 366.7 L203.1 367.4 L199.9 368.1 Z" />
+                <path class="result-residual-cell-gap" d="M199.9 362.2 L254.1 362.2 L254.1 356.7 L250.9 357.3 L247.7 358.0 L244.5 358.6 L241.3 359.2 L238.1 359.9 L235.0 360.6 L231.8 361.2 L228.6 361.9 L225.4 362.6 L222.2 363.2 L219.0 363.9 L215.9 364.6 L212.7 365.3 L209.5 366.0 L206.3 366.7 L203.1 367.4 L199.9 368.1 Z" />
                 <circle cx="227.0" cy="362.2" r="3.2" />
               </g>
-<g class="open-result-residual-cell">
+<g class="result-residual-cell">
                 <rect x="254.1" y="351.4" width="65.5" height="50.6" />
-                <path class="open-result-residual-cell-gap-fill" d="M254.1 351.4 L319.6 351.4 L319.6 344.4 L315.8 345.1 L311.9 345.8 L308.0 346.5 L304.2 347.2 L300.3 347.9 L296.5 348.6 L292.6 349.3 L288.8 350.0 L284.9 350.7 L281.0 351.4 L277.2 352.2 L273.3 352.9 L269.5 353.6 L265.6 354.4 L261.8 355.1 L257.9 355.9 L254.1 356.7 Z" />
-                <path class="open-result-residual-cell-gap" d="M254.1 351.4 L319.6 351.4 L319.6 344.4 L315.8 345.1 L311.9 345.8 L308.0 346.5 L304.2 347.2 L300.3 347.9 L296.5 348.6 L292.6 349.3 L288.8 350.0 L284.9 350.7 L281.0 351.4 L277.2 352.2 L273.3 352.9 L269.5 353.6 L265.6 354.4 L261.8 355.1 L257.9 355.9 L254.1 356.7 Z" />
+                <path class="result-residual-cell-gap-fill" d="M254.1 351.4 L319.6 351.4 L319.6 344.4 L315.8 345.1 L311.9 345.8 L308.0 346.5 L304.2 347.2 L300.3 347.9 L296.5 348.6 L292.6 349.3 L288.8 350.0 L284.9 350.7 L281.0 351.4 L277.2 352.2 L273.3 352.9 L269.5 353.6 L265.6 354.4 L261.8 355.1 L257.9 355.9 L254.1 356.7 Z" />
+                <path class="result-residual-cell-gap" d="M254.1 351.4 L319.6 351.4 L319.6 344.4 L315.8 345.1 L311.9 345.8 L308.0 346.5 L304.2 347.2 L300.3 347.9 L296.5 348.6 L292.6 349.3 L288.8 350.0 L284.9 350.7 L281.0 351.4 L277.2 352.2 L273.3 352.9 L269.5 353.6 L265.6 354.4 L261.8 355.1 L257.9 355.9 L254.1 356.7 Z" />
                 <circle cx="281.1" cy="351.4" r="3.2" />
               </g>
-<g class="open-result-residual-cell">
+<g class="result-residual-cell">
                 <rect x="319.6" y="337.9" width="62.4" height="64.1" />
-                <path class="open-result-residual-cell-gap-fill" d="M319.6 337.9 L382.0 337.9 L382.0 334.0 L378.3 334.6 L374.7 335.2 L371.0 335.8 L367.3 336.4 L363.6 336.9 L360.0 337.5 L356.3 338.2 L352.6 338.8 L349.0 339.4 L345.3 340.0 L341.6 340.6 L338.0 341.2 L334.3 341.9 L330.6 342.5 L326.9 343.1 L323.3 343.8 L319.6 344.4 Z" />
-                <path class="open-result-residual-cell-gap" d="M319.6 337.9 L382.0 337.9 L382.0 334.0 L378.3 334.6 L374.7 335.2 L371.0 335.8 L367.3 336.4 L363.6 336.9 L360.0 337.5 L356.3 338.2 L352.6 338.8 L349.0 339.4 L345.3 340.0 L341.6 340.6 L338.0 341.2 L334.3 341.9 L330.6 342.5 L326.9 343.1 L323.3 343.8 L319.6 344.4 Z" />
+                <path class="result-residual-cell-gap-fill" d="M319.6 337.9 L382.0 337.9 L382.0 334.0 L378.3 334.6 L374.7 335.2 L371.0 335.8 L367.3 336.4 L363.6 336.9 L360.0 337.5 L356.3 338.2 L352.6 338.8 L349.0 339.4 L345.3 340.0 L341.6 340.6 L338.0 341.2 L334.3 341.9 L330.6 342.5 L326.9 343.1 L323.3 343.8 L319.6 344.4 Z" />
+                <path class="result-residual-cell-gap" d="M319.6 337.9 L382.0 337.9 L382.0 334.0 L378.3 334.6 L374.7 335.2 L371.0 335.8 L367.3 336.4 L363.6 336.9 L360.0 337.5 L356.3 338.2 L352.6 338.8 L349.0 339.4 L345.3 340.0 L341.6 340.6 L338.0 341.2 L334.3 341.9 L330.6 342.5 L326.9 343.1 L323.3 343.8 L319.6 344.4 Z" />
                 <circle cx="358.1" cy="337.9" r="3.2" />
               </g>
-              <g class="open-result-residual-baseline-marker">
+              <g class="result-residual-baseline-marker">
                 <line x1="227.0" y1="402" x2="227.0" y2="362.2" />
                 <circle cx="227.0" cy="362.2" r="3.6" />
               </g>
-              <path class="open-result-primer-curve" d="M72.0 402.0 L75.5 400.9 L79.0 399.8 L82.4 398.7 L85.9 397.7 L89.4 396.6 L92.9 395.6 L96.4 394.6 L99.9 393.6 L103.3 392.5 L106.8 391.6 L110.3 390.6 L113.8 389.6 L117.3 388.6 L120.8 387.7 L124.2 386.7 L127.7 385.8 L131.2 384.9 L134.7 383.9 L138.2 383.0 L141.7 382.1 L145.1 381.2 L148.6 380.3 L152.1 379.4 L155.6 378.6 L159.1 377.7 L162.6 376.9 L166.0 376.0 L169.5 375.2 L173.0 374.3 L176.5 373.5 L180.0 372.7 L183.5 371.9 L186.9 371.1 L190.4 370.3 L193.9 369.5 L197.4 368.7 L200.9 367.9 L204.4 367.1 L207.8 366.3 L211.3 365.6 L214.8 364.8 L218.3 364.1 L221.8 363.3 L225.3 362.6 L228.7 361.9 L232.2 361.1 L235.7 360.4 L239.2 359.7 L242.7 359.0 L246.2 358.3 L249.6 357.6 L253.1 356.9 L256.6 356.2 L260.1 355.5 L263.6 354.8 L267.1 354.1 L270.5 353.4 L274.0 352.8 L277.5 352.1 L281.0 351.4 L284.5 350.8 L288.0 350.1 L291.4 349.5 L294.9 348.8 L298.4 348.2 L301.9 347.6 L305.4 346.9 L308.9 346.3 L312.3 345.7 L315.8 345.1 L319.3 344.5 L322.8 343.8 L326.3 343.2 L329.8 342.6 L333.2 342.0 L336.7 341.4 L340.2 340.8 L343.7 340.3 L347.2 339.7 L350.7 339.1 L354.1 338.5 L357.6 337.9 L361.1 337.4 L364.6 336.8 L368.1 336.2 L371.6 335.7 L375.0 335.1 L378.5 334.6 L382.0 334.0" />
+              <path class="result-primer-curve" d="M72.0 402.0 L75.5 400.9 L79.0 399.8 L82.4 398.7 L85.9 397.7 L89.4 396.6 L92.9 395.6 L96.4 394.6 L99.9 393.6 L103.3 392.5 L106.8 391.6 L110.3 390.6 L113.8 389.6 L117.3 388.6 L120.8 387.7 L124.2 386.7 L127.7 385.8 L131.2 384.9 L134.7 383.9 L138.2 383.0 L141.7 382.1 L145.1 381.2 L148.6 380.3 L152.1 379.4 L155.6 378.6 L159.1 377.7 L162.6 376.9 L166.0 376.0 L169.5 375.2 L173.0 374.3 L176.5 373.5 L180.0 372.7 L183.5 371.9 L186.9 371.1 L190.4 370.3 L193.9 369.5 L197.4 368.7 L200.9 367.9 L204.4 367.1 L207.8 366.3 L211.3 365.6 L214.8 364.8 L218.3 364.1 L221.8 363.3 L225.3 362.6 L228.7 361.9 L232.2 361.1 L235.7 360.4 L239.2 359.7 L242.7 359.0 L246.2 358.3 L249.6 357.6 L253.1 356.9 L256.6 356.2 L260.1 355.5 L263.6 354.8 L267.1 354.1 L270.5 353.4 L274.0 352.8 L277.5 352.1 L281.0 351.4 L284.5 350.8 L288.0 350.1 L291.4 349.5 L294.9 348.8 L298.4 348.2 L301.9 347.6 L305.4 346.9 L308.9 346.3 L312.3 345.7 L315.8 345.1 L319.3 344.5 L322.8 343.8 L326.3 343.2 L329.8 342.6 L333.2 342.0 L336.7 341.4 L340.2 340.8 L343.7 340.3 L347.2 339.7 L350.7 339.1 L354.1 338.5 L357.6 337.9 L361.1 337.4 L364.6 336.8 L368.1 336.2 L371.6 335.7 L375.0 335.1 L378.5 334.6 L382.0 334.0" />
             </g>
           </svg>
           <figcaption>Figure 7. Residual location by public integrand. Grey marks the run baseline, blue marks the accepted rule, and hatching shows local accepted-rule residual area.</figcaption>
         </figure>
-<figure class="open-result-paper-table" id="table-3">
-          <div class="open-result-table-wrap">
-            <table class="open-result-table">
+<figure class="result-paper-table" id="table-3">
+          <div class="result-table-wrap">
+            <table class="result-table">
               <thead>
                 <tr>
                   <th>Integrand</th>

--- a/results/quadrature-rule-optimization/run/index.html
+++ b/results/quadrature-rule-optimization/run/index.html
@@ -6,7 +6,7 @@
     <title>Quadrature Evolution Trace | Göther Labs</title>
     <meta
       name="description"
-      content="An animated replay of the quadrature optimization trace, aligned with the published open-result whitepaper."
+      content="An animated replay of the quadrature optimization trace, aligned with the published result whitepaper."
     >
     <meta name="robots" content="noindex, nofollow">
     <link rel="preload" href="/assets/fonts/inter-latin.woff2" as="font" type="font/woff2" crossorigin>

--- a/results/rcpsp-psplib-j30/artifacts/evolution.json
+++ b/results/rcpsp-psplib-j30/artifacts/evolution.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": "open-result-evolution/v1",
+  "schema_version": "result-evolution/v1",
   "title": "PSPLIB J30 RCPSP evolution chain",
   "direction": "lower_is_better",
   "baseline_score": 14.312164873860446,

--- a/results/rcpsp-psplib-j30/artifacts/provenance.json
+++ b/results/rcpsp-psplib-j30/artifacts/provenance.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": "open-result-provenance/v1",
+  "schema_version": "result-provenance/v1",
   "source_domain": "rcpsp_psplib_j30",
   "source_run": "domains/rcpsp_psplib_j30/outputs/2026-05-12/16-51-54",
   "accepted_candidate_id": "gen-119-i1-w1-a0-cbdd3ba1835131eb",

--- a/results/rcpsp-psplib-j30/artifacts/replay.json
+++ b/results/rcpsp-psplib-j30/artifacts/replay.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": "open-result-replay/v1",
+  "schema_version": "result-replay/v1",
   "accepted_candidate_id": "gen-119-i1-w1-a0-cbdd3ba1835131eb",
   "replay_status": "pass",
   "recorded_score": 12.086633114086395,

--- a/results/rcpsp-psplib-j30/index.html
+++ b/results/rcpsp-psplib-j30/index.html
@@ -33,7 +33,7 @@
     <script defer src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js"></script>
 
   </head>
-  <body class="open-result-rcpsp-page">
+  <body class="result-rcpsp-page">
     <a class="skip-link" href="#site-main">Skip to content</a>
     <div class="page-shell site-shell">
       <header class="site-header">
@@ -48,13 +48,13 @@
       </header>
 
       <main class="site-main" id="site-main">
-        <section class="hero compact-hero page-hero open-result-detail-hero rcpsp-detail-hero">
+        <section class="hero compact-hero page-hero result-detail-hero rcpsp-detail-hero">
           <h1 class="page-title">PSPLIB J30 scheduling benchmark</h1>
           <p class="intro results-hero-intro">A deterministic resource-constrained project scheduling rule improved across a frozen PSPLIB J30 subset with proven optimal makespans. The public chain reduced the lower-is-better score from 14.312 to 12.087 while keeping feasibility at 100%.</p>
         </section>
 
-        <section class="open-result-detail open-result-whitepaper-shell rcpsp-whitepaper-shell">
-          <article class="open-result-article open-result-whitepaper rcpsp-whitepaper">
+        <section class="result-detail result-whitepaper-shell rcpsp-whitepaper-shell">
+          <article class="result-article result-whitepaper rcpsp-whitepaper">
 <h3>Abstract</h3>
 <p>This note reports a deterministic dispatch rule for the Resource-Constrained Project Scheduling Problem (RCPSP). On a frozen public subset of PSPLIB J30, the evolutionary chain reduced the lower-is-better acceptance score from 14.312 to 12.087, a 15.55% reduction, while preserving feasibility on all 80 evaluated instances.</p>
 <p>For audit clarity, the public claim is the curated evolutionary chain, or cadena evolutiva, not a claim about the final isolated diagnostic run.</p>
@@ -68,9 +68,9 @@ C_{max}(S) = \max_i F_i
   <span class="equation-number">(1)</span>
 </div>
 <p>where \(F_i\) is the finish time of activity \(i\) in schedule \(S\).</p>
-<figure class="open-result-primer-card open-result-paper-figure rcpsp-inline-figure rcpsp-schedule-figure" id="fig-1">
-          <svg class="open-result-primer-svg rcpsp-paper-svg" viewBox="0 0 560 328" role="img" aria-label="RCPSP schedule readout with precedence network and Gantt schedule.">
-            <text class="open-result-axis-label open-result-figure-title" x="72" y="34">RCPSP schedule readout</text>
+<figure class="result-primer-card result-paper-figure rcpsp-inline-figure rcpsp-schedule-figure" id="fig-1">
+          <svg class="result-primer-svg rcpsp-paper-svg" viewBox="0 0 560 328" role="img" aria-label="RCPSP schedule readout with precedence network and Gantt schedule.">
+            <text class="result-axis-label result-figure-title" x="72" y="34">RCPSP schedule readout</text>
             <text class="rcpsp-paper-note" x="72" y="55">Eligible activities are ranked first; the evaluator then commits them to the earliest feasible placement.</text>
             <text class="rcpsp-paper-section-label" x="72" y="82">precedence network</text>
             <g class="rcpsp-network">
@@ -88,8 +88,8 @@ C_{max}(S) = \max_i F_i
             <text class="rcpsp-paper-note" x="72" y="192">A task becomes eligible only after all predecessor arcs are satisfied.</text>
             <text class="rcpsp-paper-section-label" x="72" y="212">Gantt schedule</text>
             <g class="rcpsp-gantt">
-              <path class="open-result-objective-grid" d="M126 234H512M126 256H512M126 278H512" />
-              <path class="open-result-rule-paper-axis" d="M126 292H512" />
+              <path class="result-objective-grid" d="M126 234H512M126 256H512M126 278H512" />
+              <path class="result-rule-paper-axis" d="M126 292H512" />
               <text x="72" y="238">row 1</text>
               <text x="72" y="260">row 2</text>
               <text x="72" y="282">row 3</text>
@@ -108,13 +108,13 @@ C_{max}(S) = \max_i F_i
           </svg>
           <figcaption>Figure 1. RCPSP schedule readout. The standard schedule view combines the precedence network, Gantt placement, and makespan marker.</figcaption>
         </figure>
-<figure class="open-result-primer-card open-result-paper-figure rcpsp-inline-figure rcpsp-resource-figure" id="fig-2">
-          <svg class="open-result-primer-svg rcpsp-paper-svg" viewBox="0 0 560 306" role="img" aria-label="Renewable resource load profile for an RCPSP schedule.">
-            <text class="open-result-axis-label open-result-figure-title" x="72" y="34">Renewable resource load</text>
+<figure class="result-primer-card result-paper-figure rcpsp-inline-figure rcpsp-resource-figure" id="fig-2">
+          <svg class="result-primer-svg rcpsp-paper-svg" viewBox="0 0 560 306" role="img" aria-label="Renewable resource load profile for an RCPSP schedule.">
+            <text class="result-axis-label result-figure-title" x="72" y="34">Renewable resource load</text>
             <text class="rcpsp-paper-note" x="72" y="55">A schedule is feasible only while every time bucket stays at or below capacity.</text>
             <g transform="translate(82 74)">
-              <path class="open-result-objective-grid" d="M42 144H430M42 108H430M42 72H430M42 36H430" />
-              <path class="open-result-rule-paper-axis" d="M42 0V174H430" />
+              <path class="result-objective-grid" d="M42 144H430M42 108H430M42 72H430M42 36H430" />
+              <path class="result-rule-paper-axis" d="M42 0V174H430" />
               <path class="rcpsp-capacity-line" d="M42 54H430" />
               <text class="rcpsp-paper-section-label" x="408" y="46" text-anchor="end">capacity</text>
               <rect class="rcpsp-load" x="55" y="108" width="36" height="66" />
@@ -126,16 +126,16 @@ C_{max}(S) = \max_i F_i
               <rect class="rcpsp-load" x="331" y="120" width="36" height="54" />
               <rect class="rcpsp-load" x="377" y="132" width="36" height="42" />
               <rect class="rcpsp-load-window" x="143" y="24" width="92" height="150" />
-              <text class="open-result-axis-tick open-result-objective-y-label" x="30" y="148">0</text>
-              <text class="open-result-axis-tick open-result-objective-y-label" x="30" y="112">1</text>
-              <text class="open-result-axis-tick open-result-objective-y-label" x="30" y="76">2</text>
-              <text class="open-result-axis-tick open-result-objective-y-label" x="30" y="40">3</text>
-              <text class="open-result-axis-tick" x="42" y="196">0</text>
-              <text class="open-result-axis-tick" x="190" y="196">20</text>
-              <text class="open-result-axis-tick" x="337" y="196">40</text>
-              <text class="open-result-axis-tick" x="430" y="196">60</text>
-              <text class="open-result-axis-label open-result-x-axis-title" x="236" y="226">time bucket</text>
-              <text class="open-result-axis-label open-result-objective-y-title" x="0" y="87" transform="rotate(-90 0 87)">active demand</text>
+              <text class="result-axis-tick result-objective-y-label" x="30" y="148">0</text>
+              <text class="result-axis-tick result-objective-y-label" x="30" y="112">1</text>
+              <text class="result-axis-tick result-objective-y-label" x="30" y="76">2</text>
+              <text class="result-axis-tick result-objective-y-label" x="30" y="40">3</text>
+              <text class="result-axis-tick" x="42" y="196">0</text>
+              <text class="result-axis-tick" x="190" y="196">20</text>
+              <text class="result-axis-tick" x="337" y="196">40</text>
+              <text class="result-axis-tick" x="430" y="196">60</text>
+              <text class="result-axis-label result-x-axis-title" x="236" y="226">time bucket</text>
+              <text class="result-axis-label result-objective-y-title" x="0" y="87" transform="rotate(-90 0 87)">active demand</text>
               <text class="rcpsp-paper-note" x="42" y="258">The fixed evaluator rejects any placement that crosses the capacity line.</text>
             </g>
           </svg>
@@ -144,9 +144,9 @@ C_{max}(S) = \max_i F_i
 <p>The evaluator uses serial schedule generation. At each step it finds eligible activities, scores each one with the candidate rule, asks the selector to choose one eligible activity, and places that activity at the earliest resource-feasible start time. This keeps the optimization surface narrow: the candidate changes priority logic, not the scheduling validator.</p>
 <h3>2. Benchmark and evaluation contract</h3>
 <p>The public portfolio contains 80 frozen PSPLIB J30 single-mode instances. The selection is parameters \(\{1, 7, 13, 19, 25, 31, 37, 43\}\) crossed with instances 1 through 10. Every instance has 32 jobs including dummy source and sink jobs, renewable-resource capacities, precedence arcs, and a proven optimal makespan.</p>
-<figure class="open-result-paper-table rcpsp-contract-table" id="table-1">
-          <div class="open-result-table-wrap">
-            <table class="open-result-table">
+<figure class="result-paper-table rcpsp-contract-table" id="table-1">
+          <div class="result-table-wrap">
+            <table class="result-table">
               <thead>
                 <tr>
                   <th>Field</th>
@@ -196,515 +196,515 @@ score = mean(g_k) + 0.35 \cdot p95(g_k) + feasibility\_penalty.
 <p>A candidate must keep the feasibility penalty at zero. It must return finite priority scores, choose only eligible activities, schedule every activity exactly once, respect all precedences, and never exceed renewable resource capacities.</p>
 <h3>3. Accepted candidate</h3>
 <p>The accepted candidate keeps the serial schedule generator unchanged and changes only the activity-ranking policy. The final rule combines critical-path urgency, successor-unlocking pressure, bottleneck resource pressure, resource pressure, wait pressure, and remaining-work pressure. The selector then prefers activities that can start earlier and uses the priority score as the second-order decision.</p>
-<figure class="open-result-paper-code open-result-code-figure rcpsp-code-figure" id="listing-1">
+<figure class="result-paper-code result-code-figure rcpsp-code-figure" id="listing-1">
           <pre><code><span class="code-line"><span class="line-no">1</span><span class="line-src"><span class="py-keyword">def</span> priority_score(</span></span><span class="code-line"><span class="line-no">2</span><span class="line-src">    activity: ActivityView,</span></span><span class="code-line"><span class="line-no">3</span><span class="line-src">    state: ScheduleStateView,</span></span><span class="code-line"><span class="line-no">4</span><span class="line-src">    instance: InstanceView,</span></span><span class="code-line"><span class="line-no">5</span><span class="line-src">) -&gt; <span class="py-builtin">float</span>:</span></span><span class="code-line"><span class="line-no">6</span><span class="line-src">    <span class="py-string">&quot;&quot;&quot;Return a deterministic priority score <span class="py-keyword">for</span> one eligible RCPSP activity.&quot;&quot;&quot;</span></span></span><span class="code-line"><span class="line-no">7</span><span class="line-src">    <span class="py-comment"># Critical path urgency: prioritize jobs that are on the critical path</span></span></span><span class="code-line"><span class="line-no">8</span><span class="line-src">    cp_score = activity.critical_path_tail * 3.0</span></span><span class="code-line"><span class="line-no">9</span><span class="line-src">    <span class="py-comment"># Downstream impact: prioritize jobs that unlock more work</span></span></span><span class="code-line"><span class="line-no">10</span><span class="line-src">    unlock_score = (</span></span><span class="code-line"><span class="line-no">11</span><span class="line-src">        activity.successor_work * 0.15</span></span><span class="code-line"><span class="line-no">12</span><span class="line-src">        + activity.transitive_successor_count * 1.5</span></span><span class="code-line"><span class="line-no">13</span><span class="line-src">    )</span></span><span class="code-line"><span class="line-no">14</span><span class="line-src">    <span class="py-comment"># Resource contention: prioritize jobs that are bottleneck-heavy</span></span></span><span class="code-line"><span class="line-no">15</span><span class="line-src">    resource_score = (</span></span><span class="code-line"><span class="line-no">16</span><span class="line-src">        activity.bottleneck_ratio * 100.0</span></span><span class="code-line"><span class="line-no">17</span><span class="line-src">        + activity.resource_pressure * 10.0</span></span><span class="code-line"><span class="line-no">18</span><span class="line-src">    )</span></span><span class="code-line"><span class="line-no">19</span><span class="line-src">    <span class="py-comment"># Urgency: penalize jobs that have been waiting past their earliest possible start</span></span></span><span class="code-line"><span class="line-no">20</span><span class="line-src">    wait_time = <span class="py-builtin">max</span>(0, state.current_makespan - state.earliest_precedence_start)</span></span><span class="code-line"><span class="line-no">21</span><span class="line-src">    wait_score = wait_time * 1.5</span></span><span class="code-line"><span class="line-no">22</span><span class="line-src">    <span class="py-comment"># Remaining work pressure: scale priority based on total remaining work to maintain throughput</span></span></span><span class="code-line"><span class="line-no">23</span><span class="line-src">    remaining_score = state.remaining_work * 0.05</span></span><span class="code-line"><span class="line-no">24</span><span class="line-src">    <span class="py-comment"># Final score with tie-breaker based on job ID</span></span></span><span class="code-line"><span class="line-no">25</span><span class="line-src">    <span class="py-keyword">return</span> (</span></span><span class="code-line"><span class="line-no">26</span><span class="line-src">        cp_score</span></span><span class="code-line"><span class="line-no">27</span><span class="line-src">        + unlock_score</span></span><span class="code-line"><span class="line-no">28</span><span class="line-src">        + resource_score</span></span><span class="code-line"><span class="line-no">29</span><span class="line-src">        + wait_score</span></span><span class="code-line"><span class="line-no">30</span><span class="line-src">        + remaining_score</span></span><span class="code-line"><span class="line-no">31</span><span class="line-src">        - (0.01 * activity.id)</span></span><span class="code-line"><span class="line-no">32</span><span class="line-src">    )</span></span><span class="code-line"><span class="line-no">33</span><span class="line-src"> </span></span><span class="code-line"><span class="line-no">34</span><span class="line-src"><span class="py-keyword">def</span> select_activity(</span></span><span class="code-line"><span class="line-no">35</span><span class="line-src">    eligible_activities: tuple[EligibleActivityView, ...],</span></span><span class="code-line"><span class="line-no">36</span><span class="line-src">    instance: InstanceView,</span></span><span class="code-line"><span class="line-no">37</span><span class="line-src">) -&gt; <span class="py-builtin">int</span>:</span></span><span class="code-line"><span class="line-no">38</span><span class="line-src">    <span class="py-string">&quot;&quot;&quot;Choose one eligible activity after all local priority scores are available.&quot;&quot;&quot;</span></span></span><span class="code-line"><span class="line-no">39</span><span class="line-src">    <span class="py-comment"># Prioritize earlier start times to keep resources busy, then use the refined priority score.</span></span></span><span class="code-line"><span class="line-no">40</span><span class="line-src">    selected = <span class="py-builtin">min</span>(</span></span><span class="code-line"><span class="line-no">41</span><span class="line-src">        eligible_activities,</span></span><span class="code-line"><span class="line-no">42</span><span class="line-src">        key=<span class="py-keyword">lambda</span> item: (</span></span><span class="code-line"><span class="line-no">43</span><span class="line-src">            item.state.earliest_resource_feasible_start,</span></span><span class="code-line"><span class="line-no">44</span><span class="line-src">            -item.priority,</span></span><span class="code-line"><span class="line-no">45</span><span class="line-src">        ),</span></span><span class="code-line"><span class="line-no">46</span><span class="line-src">    )</span></span><span class="code-line"><span class="line-no">47</span><span class="line-src">    <span class="py-keyword">return</span> <span class="py-builtin">int</span>(selected.activity.id)</span></span></code></pre>
           <figcaption>Listing 1. Accepted candidate implementation, formatted for inspection.</figcaption>
         </figure>
 <p>This is intentionally inspectable. The candidate is not a solver replacement or a hidden search procedure. It is a deterministic dispatch rule inside a fixed evaluator.</p>
 <h3>4. Results</h3>
 <p>The public chain moved from the seed score of 14.312 to an accepted score of 12.087. Figure 3 shows the full scored-candidate trace; Figure 4 summarizes the reported seed-versus-accepted comparison.</p>
-<figure class="open-result-primer-card open-result-paper-figure rcpsp-inline-figure open-result-objective-figure" id="fig-3">
-          <svg class="open-result-primer-svg open-result-objective-svg rcpsp-paper-svg" viewBox="0 0 560 328" role="img" aria-label="Best-so-far RCPSP acceptance objective.">
-            <text class="open-result-axis-label open-result-figure-title" x="82" y="34">Best-so-far acceptance objective (lower is better)</text>
-            <g class="open-result-objective-legend" transform="translate(82 48)">
-              <g transform="translate(0 0)"><circle class="open-result-objective-legend-proposal" cx="0" cy="0" r="2.4" /><text x="12" y="4">scored candidate</text></g>
-              <g transform="translate(112 0)"><line class="open-result-objective-legend-best" x1="0" y1="0" x2="16" y2="0" /><text x="24" y="4">best-so-far objective</text></g>
-              <g transform="translate(286 0)"><circle class="open-result-legend-baseline-dot" cx="0" cy="0" r="3.4" /><text x="16" y="4">baseline</text></g>
-              <g transform="translate(370 0)"><circle class="open-result-legend-accepted-dot" cx="0" cy="0" r="3.8" /><text x="16" y="4">accepted</text></g>
+<figure class="result-primer-card result-paper-figure rcpsp-inline-figure result-objective-figure" id="fig-3">
+          <svg class="result-primer-svg result-objective-svg rcpsp-paper-svg" viewBox="0 0 560 328" role="img" aria-label="Best-so-far RCPSP acceptance objective.">
+            <text class="result-axis-label result-figure-title" x="82" y="34">Best-so-far acceptance objective (lower is better)</text>
+            <g class="result-objective-legend" transform="translate(82 48)">
+              <g transform="translate(0 0)"><circle class="result-objective-legend-proposal" cx="0" cy="0" r="2.4" /><text x="12" y="4">scored candidate</text></g>
+              <g transform="translate(112 0)"><line class="result-objective-legend-best" x1="0" y1="0" x2="16" y2="0" /><text x="24" y="4">best-so-far objective</text></g>
+              <g transform="translate(286 0)"><circle class="result-legend-baseline-dot" cx="0" cy="0" r="3.4" /><text x="16" y="4">baseline</text></g>
+              <g transform="translate(370 0)"><circle class="result-legend-accepted-dot" cx="0" cy="0" r="3.8" /><text x="16" y="4">accepted</text></g>
             </g>
-            <path class="open-result-objective-grid" d="M82 76.0H512" /><text class="open-result-axis-tick open-result-objective-y-label" x="68" y="80.0">16+</text>
-            <path class="open-result-objective-grid" d="M82 164.0H512" /><text class="open-result-axis-tick open-result-objective-y-label" x="68" y="168.0">14</text>
-            <path class="open-result-objective-grid" d="M82 252.0H512" /><text class="open-result-axis-tick open-result-objective-y-label" x="68" y="256.0">12</text>
-            <path class="open-result-rule-paper-axis" d="M82 76V252H512" />
+            <path class="result-objective-grid" d="M82 76.0H512" /><text class="result-axis-tick result-objective-y-label" x="68" y="80.0">16+</text>
+            <path class="result-objective-grid" d="M82 164.0H512" /><text class="result-axis-tick result-objective-y-label" x="68" y="168.0">14</text>
+            <path class="result-objective-grid" d="M82 252.0H512" /><text class="result-axis-tick result-objective-y-label" x="68" y="256.0">12</text>
+            <path class="result-rule-paper-axis" d="M82 76V252H512" />
             <g>
-              <circle class="open-result-objective-proposal" cx="85.6" cy="169.9" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="85.6" cy="141.5" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="89.2" cy="175.4" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="89.2" cy="173.5" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="92.8" cy="178.1" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="92.8" cy="178.1" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="92.8" cy="154.3" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="92.8" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="96.5" cy="156.1" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="96.5" cy="151.8" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="96.5" cy="141.8" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="96.5" cy="125.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="100.1" cy="190.2" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="100.1" cy="163.3" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="100.1" cy="155.2" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="100.1" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="103.7" cy="171.2" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="103.7" cy="169.5" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="103.7" cy="100.4" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="103.7" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="107.3" cy="169.5" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="107.3" cy="90.6" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="107.3" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="107.3" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="110.9" cy="151.8" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="110.9" cy="150.3" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="110.9" cy="118.1" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="110.9" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="114.5" cy="167.5" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="114.5" cy="118.1" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="114.5" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="114.5" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="118.1" cy="184.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="118.1" cy="178.1" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="118.1" cy="143.9" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="118.1" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="121.7" cy="170.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="121.7" cy="155.1" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="121.7" cy="151.8" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="121.7" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="125.4" cy="182.9" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="125.4" cy="182.2" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="125.4" cy="146.7" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="125.4" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="129.0" cy="181.0" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="129.0" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="129.0" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="129.0" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="132.6" cy="156.9" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="132.6" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="132.6" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="132.6" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="136.2" cy="165.1" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="136.2" cy="131.5" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="136.2" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="136.2" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="139.8" cy="207.6" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="139.8" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="139.8" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="139.8" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="143.4" cy="136.4" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="143.4" cy="91.2" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="143.4" cy="81.2" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="143.4" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="147.0" cy="149.9" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="147.0" cy="138.4" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="147.0" cy="126.6" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="147.0" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="150.7" cy="208.8" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="150.7" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="150.7" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="150.7" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="154.3" cy="154.7" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="154.3" cy="149.7" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="154.3" cy="82.1" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="154.3" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="157.9" cy="80.1" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="157.9" cy="80.0" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="157.9" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="157.9" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="161.5" cy="182.7" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="161.5" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="161.5" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="161.5" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="165.1" cy="134.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="165.1" cy="81.2" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="165.1" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="165.1" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="168.7" cy="145.3" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="168.7" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="168.7" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="168.7" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="172.3" cy="125.7" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="172.3" cy="89.8" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="172.3" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="172.3" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="175.9" cy="159.6" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="175.9" cy="151.5" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="175.9" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="175.9" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="179.6" cy="140.7" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="179.6" cy="123.8" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="179.6" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="179.6" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="183.2" cy="146.8" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="183.2" cy="126.3" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="183.2" cy="125.6" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="183.2" cy="111.7" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="186.8" cy="120.6" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="186.8" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="186.8" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="186.8" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="190.4" cy="165.3" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="190.4" cy="129.3" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="190.4" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="190.4" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="194.0" cy="135.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="194.0" cy="132.4" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="194.0" cy="93.0" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="194.0" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="197.6" cy="157.9" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="197.6" cy="157.4" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="197.6" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="197.6" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="201.2" cy="160.6" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="201.2" cy="136.3" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="201.2" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="201.2" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="204.9" cy="162.6" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="204.9" cy="90.9" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="204.9" cy="85.4" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="204.9" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="208.5" cy="113.0" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="208.5" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="208.5" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="208.5" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="212.1" cy="187.6" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="212.1" cy="178.3" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="212.1" cy="170.2" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="212.1" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="215.7" cy="191.3" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="215.7" cy="122.2" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="215.7" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="215.7" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="219.3" cy="187.4" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="219.3" cy="114.6" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="219.3" cy="110.3" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="219.3" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="222.9" cy="158.5" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="222.9" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="222.9" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="222.9" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="226.5" cy="110.2" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="226.5" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="226.5" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="226.5" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="230.2" cy="145.2" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="230.2" cy="134.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="230.2" cy="98.8" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="230.2" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="233.8" cy="141.4" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="233.8" cy="115.0" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="233.8" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="233.8" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="237.4" cy="194.4" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="237.4" cy="158.0" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="237.4" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="237.4" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="241.0" cy="176.2" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="241.0" cy="140.1" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="241.0" cy="107.8" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="241.0" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="244.6" cy="153.9" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="244.6" cy="112.8" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="244.6" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="244.6" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="248.2" cy="147.5" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="248.2" cy="133.1" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="248.2" cy="130.6" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="248.2" cy="112.5" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="251.8" cy="208.8" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="251.8" cy="160.7" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="251.8" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="251.8" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="255.4" cy="140.5" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="255.4" cy="110.9" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="255.4" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="255.4" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="259.1" cy="169.9" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="259.1" cy="153.1" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="259.1" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="259.1" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="262.7" cy="158.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="262.7" cy="138.9" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="262.7" cy="138.9" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="262.7" cy="138.2" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="266.3" cy="173.3" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="266.3" cy="167.2" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="266.3" cy="166.7" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="266.3" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="269.9" cy="166.4" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="269.9" cy="117.5" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="269.9" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="269.9" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="273.5" cy="150.7" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="273.5" cy="142.2" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="273.5" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="273.5" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="277.1" cy="125.7" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="277.1" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="277.1" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="277.1" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="280.7" cy="106.1" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="280.7" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="280.7" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="280.7" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="284.4" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="284.4" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="284.4" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="284.4" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="288.0" cy="129.5" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="288.0" cy="85.7" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="288.0" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="288.0" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="291.6" cy="133.5" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="291.6" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="291.6" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="291.6" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="295.2" cy="146.8" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="295.2" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="295.2" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="295.2" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="298.8" cy="132.3" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="298.8" cy="98.9" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="298.8" cy="80.7" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="298.8" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="302.4" cy="215.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="302.4" cy="153.6" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="302.4" cy="122.8" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="302.4" cy="100.2" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="306.0" cy="166.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="306.0" cy="119.8" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="306.0" cy="78.8" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="306.0" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="309.6" cy="115.8" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="309.6" cy="100.0" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="309.6" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="309.6" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="313.3" cy="144.3" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="313.3" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="313.3" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="313.3" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="316.9" cy="155.4" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="316.9" cy="91.7" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="316.9" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="316.9" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="320.5" cy="194.9" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="320.5" cy="93.5" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="320.5" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="320.5" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="324.1" cy="207.4" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="324.1" cy="124.4" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="324.1" cy="90.7" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="324.1" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="327.7" cy="190.5" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="327.7" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="327.7" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="327.7" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="331.3" cy="115.6" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="331.3" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="331.3" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="331.3" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="334.9" cy="129.7" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="334.9" cy="119.3" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="334.9" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="334.9" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="338.6" cy="160.7" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="338.6" cy="154.2" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="338.6" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="338.6" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="342.2" cy="194.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="342.2" cy="163.9" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="342.2" cy="147.6" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="342.2" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="345.8" cy="225.7" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="345.8" cy="181.8" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="345.8" cy="177.1" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="345.8" cy="109.4" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="349.4" cy="197.7" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="349.4" cy="174.0" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="349.4" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="349.4" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="353.0" cy="190.0" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="353.0" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="353.0" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="353.0" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="356.6" cy="183.3" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="356.6" cy="128.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="356.6" cy="127.3" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="356.6" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="360.2" cy="139.4" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="360.2" cy="113.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="360.2" cy="82.7" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="360.2" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="363.8" cy="182.3" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="363.8" cy="131.6" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="363.8" cy="123.8" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="363.8" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="367.5" cy="202.1" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="367.5" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="367.5" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="367.5" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="371.1" cy="205.1" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="371.1" cy="111.9" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="371.1" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="371.1" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="374.7" cy="149.8" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="374.7" cy="123.0" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="374.7" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="374.7" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="378.3" cy="171.9" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="378.3" cy="144.9" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="378.3" cy="119.4" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="378.3" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="381.9" cy="238.5" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="381.9" cy="121.1" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="381.9" cy="76.5" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="381.9" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="385.5" cy="230.1" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="385.5" cy="99.0" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="385.5" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="385.5" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="389.1" cy="162.9" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="389.1" cy="122.2" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="389.1" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="389.1" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="392.8" cy="234.8" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="392.8" cy="205.1" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="392.8" cy="111.2" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="392.8" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="396.4" cy="220.8" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="396.4" cy="115.3" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="396.4" cy="77.9" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="396.4" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="400.0" cy="162.1" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="400.0" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="400.0" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="400.0" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="403.6" cy="242.1" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="403.6" cy="147.7" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="403.6" cy="122.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="403.6" cy="102.8" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="407.2" cy="203.9" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="407.2" cy="165.4" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="407.2" cy="142.6" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="407.2" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="410.8" cy="229.1" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="410.8" cy="135.6" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="410.8" cy="123.7" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="410.8" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="414.4" cy="193.1" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="414.4" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="414.4" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="414.4" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="418.1" cy="203.5" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="418.1" cy="131.8" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="418.1" cy="102.7" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="418.1" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="421.7" cy="99.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="421.7" cy="85.6" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="421.7" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="421.7" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="425.3" cy="205.8" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="425.3" cy="144.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="425.3" cy="110.5" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="425.3" cy="88.4" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="428.9" cy="157.6" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="428.9" cy="94.5" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="428.9" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="428.9" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="432.5" cy="209.3" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="432.5" cy="163.6" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="432.5" cy="135.8" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="432.5" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="436.1" cy="221.4" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="436.1" cy="140.5" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="436.1" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="436.1" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="439.7" cy="220.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="439.7" cy="78.9" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="439.7" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="439.7" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="443.3" cy="123.3" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="443.3" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="443.3" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="443.3" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="447.0" cy="230.6" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="447.0" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="447.0" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="447.0" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="450.6" cy="213.7" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="450.6" cy="148.5" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="450.6" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="450.6" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="454.2" cy="198.3" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="454.2" cy="126.9" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="454.2" cy="120.5" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="454.2" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="457.8" cy="209.8" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="457.8" cy="87.6" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="457.8" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="457.8" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="461.4" cy="160.3" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="461.4" cy="126.9" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="461.4" cy="111.1" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="461.4" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="465.0" cy="228.4" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="465.0" cy="170.8" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="465.0" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="465.0" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="468.6" cy="162.6" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="468.6" cy="123.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="468.6" cy="121.4" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="468.6" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="472.3" cy="221.4" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="472.3" cy="210.0" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="472.3" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="472.3" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="475.9" cy="230.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="475.9" cy="133.3" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="475.9" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="475.9" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="479.5" cy="218.4" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="479.5" cy="214.4" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="479.5" cy="127.6" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="479.5" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="483.1" cy="188.4" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="483.1" cy="86.7" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="483.1" cy="83.1" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="483.1" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="486.7" cy="227.5" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="486.7" cy="160.4" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="486.7" cy="152.4" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="486.7" cy="83.5" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="490.3" cy="231.5" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="490.3" cy="135.3" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="490.3" cy="114.8" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="490.3" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="493.9" cy="227.5" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="493.9" cy="193.6" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="493.9" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="493.9" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="497.5" cy="186.8" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="497.5" cy="114.8" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="497.5" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="497.5" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="501.2" cy="209.8" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="501.2" cy="184.1" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="501.2" cy="135.7" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="501.2" cy="91.7" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="504.8" cy="222.1" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="504.8" cy="222.1" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="504.8" cy="133.3" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="504.8" cy="127.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="508.4" cy="222.1" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="508.4" cy="166.7" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="508.4" cy="114.8" r="1.6" />
-              <circle class="open-result-objective-proposal is-clipped" cx="508.4" cy="76.0" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="512.0" cy="248.2" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="512.0" cy="218.4" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="512.0" cy="140.2" r="1.6" />
-              <circle class="open-result-objective-proposal" cx="512.0" cy="110.4" r="1.6" />
+              <circle class="result-objective-proposal" cx="85.6" cy="169.9" r="1.6" />
+              <circle class="result-objective-proposal" cx="85.6" cy="141.5" r="1.6" />
+              <circle class="result-objective-proposal" cx="89.2" cy="175.4" r="1.6" />
+              <circle class="result-objective-proposal" cx="89.2" cy="173.5" r="1.6" />
+              <circle class="result-objective-proposal" cx="92.8" cy="178.1" r="1.6" />
+              <circle class="result-objective-proposal" cx="92.8" cy="178.1" r="1.6" />
+              <circle class="result-objective-proposal" cx="92.8" cy="154.3" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="92.8" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="96.5" cy="156.1" r="1.6" />
+              <circle class="result-objective-proposal" cx="96.5" cy="151.8" r="1.6" />
+              <circle class="result-objective-proposal" cx="96.5" cy="141.8" r="1.6" />
+              <circle class="result-objective-proposal" cx="96.5" cy="125.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="100.1" cy="190.2" r="1.6" />
+              <circle class="result-objective-proposal" cx="100.1" cy="163.3" r="1.6" />
+              <circle class="result-objective-proposal" cx="100.1" cy="155.2" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="100.1" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="103.7" cy="171.2" r="1.6" />
+              <circle class="result-objective-proposal" cx="103.7" cy="169.5" r="1.6" />
+              <circle class="result-objective-proposal" cx="103.7" cy="100.4" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="103.7" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="107.3" cy="169.5" r="1.6" />
+              <circle class="result-objective-proposal" cx="107.3" cy="90.6" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="107.3" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="107.3" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="110.9" cy="151.8" r="1.6" />
+              <circle class="result-objective-proposal" cx="110.9" cy="150.3" r="1.6" />
+              <circle class="result-objective-proposal" cx="110.9" cy="118.1" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="110.9" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="114.5" cy="167.5" r="1.6" />
+              <circle class="result-objective-proposal" cx="114.5" cy="118.1" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="114.5" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="114.5" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="118.1" cy="184.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="118.1" cy="178.1" r="1.6" />
+              <circle class="result-objective-proposal" cx="118.1" cy="143.9" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="118.1" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="121.7" cy="170.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="121.7" cy="155.1" r="1.6" />
+              <circle class="result-objective-proposal" cx="121.7" cy="151.8" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="121.7" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="125.4" cy="182.9" r="1.6" />
+              <circle class="result-objective-proposal" cx="125.4" cy="182.2" r="1.6" />
+              <circle class="result-objective-proposal" cx="125.4" cy="146.7" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="125.4" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="129.0" cy="181.0" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="129.0" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="129.0" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="129.0" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="132.6" cy="156.9" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="132.6" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="132.6" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="132.6" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="136.2" cy="165.1" r="1.6" />
+              <circle class="result-objective-proposal" cx="136.2" cy="131.5" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="136.2" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="136.2" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="139.8" cy="207.6" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="139.8" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="139.8" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="139.8" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="143.4" cy="136.4" r="1.6" />
+              <circle class="result-objective-proposal" cx="143.4" cy="91.2" r="1.6" />
+              <circle class="result-objective-proposal" cx="143.4" cy="81.2" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="143.4" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="147.0" cy="149.9" r="1.6" />
+              <circle class="result-objective-proposal" cx="147.0" cy="138.4" r="1.6" />
+              <circle class="result-objective-proposal" cx="147.0" cy="126.6" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="147.0" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="150.7" cy="208.8" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="150.7" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="150.7" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="150.7" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="154.3" cy="154.7" r="1.6" />
+              <circle class="result-objective-proposal" cx="154.3" cy="149.7" r="1.6" />
+              <circle class="result-objective-proposal" cx="154.3" cy="82.1" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="154.3" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="157.9" cy="80.1" r="1.6" />
+              <circle class="result-objective-proposal" cx="157.9" cy="80.0" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="157.9" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="157.9" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="161.5" cy="182.7" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="161.5" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="161.5" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="161.5" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="165.1" cy="134.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="165.1" cy="81.2" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="165.1" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="165.1" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="168.7" cy="145.3" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="168.7" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="168.7" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="168.7" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="172.3" cy="125.7" r="1.6" />
+              <circle class="result-objective-proposal" cx="172.3" cy="89.8" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="172.3" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="172.3" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="175.9" cy="159.6" r="1.6" />
+              <circle class="result-objective-proposal" cx="175.9" cy="151.5" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="175.9" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="175.9" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="179.6" cy="140.7" r="1.6" />
+              <circle class="result-objective-proposal" cx="179.6" cy="123.8" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="179.6" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="179.6" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="183.2" cy="146.8" r="1.6" />
+              <circle class="result-objective-proposal" cx="183.2" cy="126.3" r="1.6" />
+              <circle class="result-objective-proposal" cx="183.2" cy="125.6" r="1.6" />
+              <circle class="result-objective-proposal" cx="183.2" cy="111.7" r="1.6" />
+              <circle class="result-objective-proposal" cx="186.8" cy="120.6" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="186.8" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="186.8" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="186.8" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="190.4" cy="165.3" r="1.6" />
+              <circle class="result-objective-proposal" cx="190.4" cy="129.3" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="190.4" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="190.4" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="194.0" cy="135.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="194.0" cy="132.4" r="1.6" />
+              <circle class="result-objective-proposal" cx="194.0" cy="93.0" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="194.0" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="197.6" cy="157.9" r="1.6" />
+              <circle class="result-objective-proposal" cx="197.6" cy="157.4" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="197.6" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="197.6" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="201.2" cy="160.6" r="1.6" />
+              <circle class="result-objective-proposal" cx="201.2" cy="136.3" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="201.2" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="201.2" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="204.9" cy="162.6" r="1.6" />
+              <circle class="result-objective-proposal" cx="204.9" cy="90.9" r="1.6" />
+              <circle class="result-objective-proposal" cx="204.9" cy="85.4" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="204.9" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="208.5" cy="113.0" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="208.5" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="208.5" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="208.5" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="212.1" cy="187.6" r="1.6" />
+              <circle class="result-objective-proposal" cx="212.1" cy="178.3" r="1.6" />
+              <circle class="result-objective-proposal" cx="212.1" cy="170.2" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="212.1" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="215.7" cy="191.3" r="1.6" />
+              <circle class="result-objective-proposal" cx="215.7" cy="122.2" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="215.7" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="215.7" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="219.3" cy="187.4" r="1.6" />
+              <circle class="result-objective-proposal" cx="219.3" cy="114.6" r="1.6" />
+              <circle class="result-objective-proposal" cx="219.3" cy="110.3" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="219.3" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="222.9" cy="158.5" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="222.9" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="222.9" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="222.9" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="226.5" cy="110.2" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="226.5" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="226.5" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="226.5" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="230.2" cy="145.2" r="1.6" />
+              <circle class="result-objective-proposal" cx="230.2" cy="134.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="230.2" cy="98.8" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="230.2" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="233.8" cy="141.4" r="1.6" />
+              <circle class="result-objective-proposal" cx="233.8" cy="115.0" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="233.8" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="233.8" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="237.4" cy="194.4" r="1.6" />
+              <circle class="result-objective-proposal" cx="237.4" cy="158.0" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="237.4" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="237.4" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="241.0" cy="176.2" r="1.6" />
+              <circle class="result-objective-proposal" cx="241.0" cy="140.1" r="1.6" />
+              <circle class="result-objective-proposal" cx="241.0" cy="107.8" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="241.0" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="244.6" cy="153.9" r="1.6" />
+              <circle class="result-objective-proposal" cx="244.6" cy="112.8" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="244.6" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="244.6" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="248.2" cy="147.5" r="1.6" />
+              <circle class="result-objective-proposal" cx="248.2" cy="133.1" r="1.6" />
+              <circle class="result-objective-proposal" cx="248.2" cy="130.6" r="1.6" />
+              <circle class="result-objective-proposal" cx="248.2" cy="112.5" r="1.6" />
+              <circle class="result-objective-proposal" cx="251.8" cy="208.8" r="1.6" />
+              <circle class="result-objective-proposal" cx="251.8" cy="160.7" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="251.8" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="251.8" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="255.4" cy="140.5" r="1.6" />
+              <circle class="result-objective-proposal" cx="255.4" cy="110.9" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="255.4" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="255.4" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="259.1" cy="169.9" r="1.6" />
+              <circle class="result-objective-proposal" cx="259.1" cy="153.1" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="259.1" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="259.1" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="262.7" cy="158.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="262.7" cy="138.9" r="1.6" />
+              <circle class="result-objective-proposal" cx="262.7" cy="138.9" r="1.6" />
+              <circle class="result-objective-proposal" cx="262.7" cy="138.2" r="1.6" />
+              <circle class="result-objective-proposal" cx="266.3" cy="173.3" r="1.6" />
+              <circle class="result-objective-proposal" cx="266.3" cy="167.2" r="1.6" />
+              <circle class="result-objective-proposal" cx="266.3" cy="166.7" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="266.3" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="269.9" cy="166.4" r="1.6" />
+              <circle class="result-objective-proposal" cx="269.9" cy="117.5" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="269.9" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="269.9" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="273.5" cy="150.7" r="1.6" />
+              <circle class="result-objective-proposal" cx="273.5" cy="142.2" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="273.5" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="273.5" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="277.1" cy="125.7" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="277.1" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="277.1" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="277.1" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="280.7" cy="106.1" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="280.7" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="280.7" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="280.7" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="284.4" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="284.4" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="284.4" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="284.4" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="288.0" cy="129.5" r="1.6" />
+              <circle class="result-objective-proposal" cx="288.0" cy="85.7" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="288.0" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="288.0" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="291.6" cy="133.5" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="291.6" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="291.6" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="291.6" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="295.2" cy="146.8" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="295.2" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="295.2" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="295.2" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="298.8" cy="132.3" r="1.6" />
+              <circle class="result-objective-proposal" cx="298.8" cy="98.9" r="1.6" />
+              <circle class="result-objective-proposal" cx="298.8" cy="80.7" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="298.8" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="302.4" cy="215.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="302.4" cy="153.6" r="1.6" />
+              <circle class="result-objective-proposal" cx="302.4" cy="122.8" r="1.6" />
+              <circle class="result-objective-proposal" cx="302.4" cy="100.2" r="1.6" />
+              <circle class="result-objective-proposal" cx="306.0" cy="166.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="306.0" cy="119.8" r="1.6" />
+              <circle class="result-objective-proposal" cx="306.0" cy="78.8" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="306.0" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="309.6" cy="115.8" r="1.6" />
+              <circle class="result-objective-proposal" cx="309.6" cy="100.0" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="309.6" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="309.6" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="313.3" cy="144.3" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="313.3" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="313.3" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="313.3" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="316.9" cy="155.4" r="1.6" />
+              <circle class="result-objective-proposal" cx="316.9" cy="91.7" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="316.9" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="316.9" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="320.5" cy="194.9" r="1.6" />
+              <circle class="result-objective-proposal" cx="320.5" cy="93.5" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="320.5" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="320.5" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="324.1" cy="207.4" r="1.6" />
+              <circle class="result-objective-proposal" cx="324.1" cy="124.4" r="1.6" />
+              <circle class="result-objective-proposal" cx="324.1" cy="90.7" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="324.1" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="327.7" cy="190.5" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="327.7" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="327.7" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="327.7" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="331.3" cy="115.6" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="331.3" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="331.3" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="331.3" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="334.9" cy="129.7" r="1.6" />
+              <circle class="result-objective-proposal" cx="334.9" cy="119.3" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="334.9" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="334.9" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="338.6" cy="160.7" r="1.6" />
+              <circle class="result-objective-proposal" cx="338.6" cy="154.2" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="338.6" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="338.6" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="342.2" cy="194.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="342.2" cy="163.9" r="1.6" />
+              <circle class="result-objective-proposal" cx="342.2" cy="147.6" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="342.2" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="345.8" cy="225.7" r="1.6" />
+              <circle class="result-objective-proposal" cx="345.8" cy="181.8" r="1.6" />
+              <circle class="result-objective-proposal" cx="345.8" cy="177.1" r="1.6" />
+              <circle class="result-objective-proposal" cx="345.8" cy="109.4" r="1.6" />
+              <circle class="result-objective-proposal" cx="349.4" cy="197.7" r="1.6" />
+              <circle class="result-objective-proposal" cx="349.4" cy="174.0" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="349.4" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="349.4" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="353.0" cy="190.0" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="353.0" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="353.0" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="353.0" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="356.6" cy="183.3" r="1.6" />
+              <circle class="result-objective-proposal" cx="356.6" cy="128.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="356.6" cy="127.3" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="356.6" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="360.2" cy="139.4" r="1.6" />
+              <circle class="result-objective-proposal" cx="360.2" cy="113.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="360.2" cy="82.7" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="360.2" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="363.8" cy="182.3" r="1.6" />
+              <circle class="result-objective-proposal" cx="363.8" cy="131.6" r="1.6" />
+              <circle class="result-objective-proposal" cx="363.8" cy="123.8" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="363.8" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="367.5" cy="202.1" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="367.5" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="367.5" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="367.5" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="371.1" cy="205.1" r="1.6" />
+              <circle class="result-objective-proposal" cx="371.1" cy="111.9" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="371.1" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="371.1" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="374.7" cy="149.8" r="1.6" />
+              <circle class="result-objective-proposal" cx="374.7" cy="123.0" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="374.7" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="374.7" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="378.3" cy="171.9" r="1.6" />
+              <circle class="result-objective-proposal" cx="378.3" cy="144.9" r="1.6" />
+              <circle class="result-objective-proposal" cx="378.3" cy="119.4" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="378.3" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="381.9" cy="238.5" r="1.6" />
+              <circle class="result-objective-proposal" cx="381.9" cy="121.1" r="1.6" />
+              <circle class="result-objective-proposal" cx="381.9" cy="76.5" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="381.9" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="385.5" cy="230.1" r="1.6" />
+              <circle class="result-objective-proposal" cx="385.5" cy="99.0" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="385.5" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="385.5" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="389.1" cy="162.9" r="1.6" />
+              <circle class="result-objective-proposal" cx="389.1" cy="122.2" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="389.1" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="389.1" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="392.8" cy="234.8" r="1.6" />
+              <circle class="result-objective-proposal" cx="392.8" cy="205.1" r="1.6" />
+              <circle class="result-objective-proposal" cx="392.8" cy="111.2" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="392.8" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="396.4" cy="220.8" r="1.6" />
+              <circle class="result-objective-proposal" cx="396.4" cy="115.3" r="1.6" />
+              <circle class="result-objective-proposal" cx="396.4" cy="77.9" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="396.4" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="400.0" cy="162.1" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="400.0" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="400.0" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="400.0" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="403.6" cy="242.1" r="1.6" />
+              <circle class="result-objective-proposal" cx="403.6" cy="147.7" r="1.6" />
+              <circle class="result-objective-proposal" cx="403.6" cy="122.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="403.6" cy="102.8" r="1.6" />
+              <circle class="result-objective-proposal" cx="407.2" cy="203.9" r="1.6" />
+              <circle class="result-objective-proposal" cx="407.2" cy="165.4" r="1.6" />
+              <circle class="result-objective-proposal" cx="407.2" cy="142.6" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="407.2" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="410.8" cy="229.1" r="1.6" />
+              <circle class="result-objective-proposal" cx="410.8" cy="135.6" r="1.6" />
+              <circle class="result-objective-proposal" cx="410.8" cy="123.7" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="410.8" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="414.4" cy="193.1" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="414.4" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="414.4" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="414.4" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="418.1" cy="203.5" r="1.6" />
+              <circle class="result-objective-proposal" cx="418.1" cy="131.8" r="1.6" />
+              <circle class="result-objective-proposal" cx="418.1" cy="102.7" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="418.1" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="421.7" cy="99.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="421.7" cy="85.6" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="421.7" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="421.7" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="425.3" cy="205.8" r="1.6" />
+              <circle class="result-objective-proposal" cx="425.3" cy="144.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="425.3" cy="110.5" r="1.6" />
+              <circle class="result-objective-proposal" cx="425.3" cy="88.4" r="1.6" />
+              <circle class="result-objective-proposal" cx="428.9" cy="157.6" r="1.6" />
+              <circle class="result-objective-proposal" cx="428.9" cy="94.5" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="428.9" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="428.9" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="432.5" cy="209.3" r="1.6" />
+              <circle class="result-objective-proposal" cx="432.5" cy="163.6" r="1.6" />
+              <circle class="result-objective-proposal" cx="432.5" cy="135.8" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="432.5" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="436.1" cy="221.4" r="1.6" />
+              <circle class="result-objective-proposal" cx="436.1" cy="140.5" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="436.1" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="436.1" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="439.7" cy="220.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="439.7" cy="78.9" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="439.7" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="439.7" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="443.3" cy="123.3" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="443.3" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="443.3" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="443.3" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="447.0" cy="230.6" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="447.0" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="447.0" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="447.0" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="450.6" cy="213.7" r="1.6" />
+              <circle class="result-objective-proposal" cx="450.6" cy="148.5" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="450.6" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="450.6" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="454.2" cy="198.3" r="1.6" />
+              <circle class="result-objective-proposal" cx="454.2" cy="126.9" r="1.6" />
+              <circle class="result-objective-proposal" cx="454.2" cy="120.5" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="454.2" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="457.8" cy="209.8" r="1.6" />
+              <circle class="result-objective-proposal" cx="457.8" cy="87.6" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="457.8" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="457.8" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="461.4" cy="160.3" r="1.6" />
+              <circle class="result-objective-proposal" cx="461.4" cy="126.9" r="1.6" />
+              <circle class="result-objective-proposal" cx="461.4" cy="111.1" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="461.4" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="465.0" cy="228.4" r="1.6" />
+              <circle class="result-objective-proposal" cx="465.0" cy="170.8" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="465.0" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="465.0" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="468.6" cy="162.6" r="1.6" />
+              <circle class="result-objective-proposal" cx="468.6" cy="123.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="468.6" cy="121.4" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="468.6" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="472.3" cy="221.4" r="1.6" />
+              <circle class="result-objective-proposal" cx="472.3" cy="210.0" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="472.3" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="472.3" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="475.9" cy="230.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="475.9" cy="133.3" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="475.9" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="475.9" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="479.5" cy="218.4" r="1.6" />
+              <circle class="result-objective-proposal" cx="479.5" cy="214.4" r="1.6" />
+              <circle class="result-objective-proposal" cx="479.5" cy="127.6" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="479.5" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="483.1" cy="188.4" r="1.6" />
+              <circle class="result-objective-proposal" cx="483.1" cy="86.7" r="1.6" />
+              <circle class="result-objective-proposal" cx="483.1" cy="83.1" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="483.1" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="486.7" cy="227.5" r="1.6" />
+              <circle class="result-objective-proposal" cx="486.7" cy="160.4" r="1.6" />
+              <circle class="result-objective-proposal" cx="486.7" cy="152.4" r="1.6" />
+              <circle class="result-objective-proposal" cx="486.7" cy="83.5" r="1.6" />
+              <circle class="result-objective-proposal" cx="490.3" cy="231.5" r="1.6" />
+              <circle class="result-objective-proposal" cx="490.3" cy="135.3" r="1.6" />
+              <circle class="result-objective-proposal" cx="490.3" cy="114.8" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="490.3" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="493.9" cy="227.5" r="1.6" />
+              <circle class="result-objective-proposal" cx="493.9" cy="193.6" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="493.9" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="493.9" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="497.5" cy="186.8" r="1.6" />
+              <circle class="result-objective-proposal" cx="497.5" cy="114.8" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="497.5" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="497.5" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="501.2" cy="209.8" r="1.6" />
+              <circle class="result-objective-proposal" cx="501.2" cy="184.1" r="1.6" />
+              <circle class="result-objective-proposal" cx="501.2" cy="135.7" r="1.6" />
+              <circle class="result-objective-proposal" cx="501.2" cy="91.7" r="1.6" />
+              <circle class="result-objective-proposal" cx="504.8" cy="222.1" r="1.6" />
+              <circle class="result-objective-proposal" cx="504.8" cy="222.1" r="1.6" />
+              <circle class="result-objective-proposal" cx="504.8" cy="133.3" r="1.6" />
+              <circle class="result-objective-proposal" cx="504.8" cy="127.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="508.4" cy="222.1" r="1.6" />
+              <circle class="result-objective-proposal" cx="508.4" cy="166.7" r="1.6" />
+              <circle class="result-objective-proposal" cx="508.4" cy="114.8" r="1.6" />
+              <circle class="result-objective-proposal is-clipped" cx="508.4" cy="76.0" r="1.6" />
+              <circle class="result-objective-proposal" cx="512.0" cy="248.2" r="1.6" />
+              <circle class="result-objective-proposal" cx="512.0" cy="218.4" r="1.6" />
+              <circle class="result-objective-proposal" cx="512.0" cy="140.2" r="1.6" />
+              <circle class="result-objective-proposal" cx="512.0" cy="110.4" r="1.6" />
             </g>
-            <path class="open-result-objective-best" d="M 82.0 150.3 L 85.6 169.9 L 89.2 175.4 L 92.8 178.1 L 96.5 178.1 L 100.1 190.2 L 103.7 190.2 L 107.3 190.2 L 110.9 190.2 L 114.5 190.2 L 118.1 190.2 L 121.7 190.2 L 125.4 190.2 L 129.0 190.2 L 132.6 190.2 L 136.2 190.2 L 139.8 207.6 L 143.4 207.6 L 147.0 207.6 L 150.7 208.8 L 154.3 208.8 L 157.9 208.8 L 161.5 208.8 L 165.1 208.8 L 168.7 208.8 L 172.3 208.8 L 175.9 208.8 L 179.6 208.8 L 183.2 208.8 L 186.8 208.8 L 190.4 208.8 L 194.0 208.8 L 197.6 208.8 L 201.2 208.8 L 204.9 208.8 L 208.5 208.8 L 212.1 208.8 L 215.7 208.8 L 219.3 208.8 L 222.9 208.8 L 226.5 208.8 L 230.2 208.8 L 233.8 208.8 L 237.4 208.8 L 241.0 208.8 L 244.6 208.8 L 248.2 208.8 L 251.8 208.8 L 255.4 208.8 L 259.1 208.8 L 262.7 208.8 L 266.3 208.8 L 269.9 208.8 L 273.5 208.8 L 277.1 208.8 L 280.7 208.8 L 284.4 208.8 L 288.0 208.8 L 291.6 208.8 L 295.2 208.8 L 298.8 208.8 L 302.4 215.0 L 306.0 215.0 L 309.6 215.0 L 313.3 215.0 L 316.9 215.0 L 320.5 215.0 L 324.1 215.0 L 327.7 215.0 L 331.3 215.0 L 334.9 215.0 L 338.6 215.0 L 342.2 215.0 L 345.8 225.7 L 349.4 225.7 L 353.0 225.7 L 356.6 225.7 L 360.2 225.7 L 363.8 225.7 L 367.5 225.7 L 371.1 225.7 L 374.7 225.7 L 378.3 225.7 L 381.9 238.5 L 385.5 238.5 L 389.1 238.5 L 392.8 238.5 L 396.4 238.5 L 400.0 238.5 L 403.6 242.1 L 407.2 242.1 L 410.8 242.1 L 414.4 242.1 L 418.1 242.1 L 421.7 242.1 L 425.3 242.1 L 428.9 242.1 L 432.5 242.1 L 436.1 242.1 L 439.7 242.1 L 443.3 242.1 L 447.0 242.1 L 450.6 242.1 L 454.2 242.1 L 457.8 242.1 L 461.4 242.1 L 465.0 242.1 L 468.6 242.1 L 472.3 242.1 L 475.9 242.1 L 479.5 242.1 L 483.1 242.1 L 486.7 242.1 L 490.3 242.1 L 493.9 242.1 L 497.5 242.1 L 501.2 242.1 L 504.8 242.1 L 508.4 242.1 L 512.0 248.2" />
-            <g class="open-result-objective-baseline"><circle cx="82.0" cy="150.3" r="4.2" /></g>
-            <g class="open-result-objective-accepted"><circle cx="512.0" cy="248.2" r="4.8" /></g>
-            <text class="open-result-axis-tick" x="82.0" y="282">0</text>
-            <text class="open-result-axis-tick" x="226.5" y="282" text-anchor="middle">40</text>
-            <text class="open-result-axis-tick" x="371.1" y="282" text-anchor="middle">80</text>
-            <text class="open-result-axis-tick" x="512.0" y="282" text-anchor="end">119</text>
-            <text class="open-result-axis-label open-result-x-axis-title" x="297.0" y="306">generation <tspan font-style="italic">k</tspan></text>
-            <text class="open-result-axis-label open-result-objective-y-title" x="34" y="164.0" transform="rotate(-90 34 164.0)"><tspan font-style="italic">J</tspan><tspan>(</tspan><tspan font-style="italic">r</tspan><tspan>)</tspan></text>
+            <path class="result-objective-best" d="M 82.0 150.3 L 85.6 169.9 L 89.2 175.4 L 92.8 178.1 L 96.5 178.1 L 100.1 190.2 L 103.7 190.2 L 107.3 190.2 L 110.9 190.2 L 114.5 190.2 L 118.1 190.2 L 121.7 190.2 L 125.4 190.2 L 129.0 190.2 L 132.6 190.2 L 136.2 190.2 L 139.8 207.6 L 143.4 207.6 L 147.0 207.6 L 150.7 208.8 L 154.3 208.8 L 157.9 208.8 L 161.5 208.8 L 165.1 208.8 L 168.7 208.8 L 172.3 208.8 L 175.9 208.8 L 179.6 208.8 L 183.2 208.8 L 186.8 208.8 L 190.4 208.8 L 194.0 208.8 L 197.6 208.8 L 201.2 208.8 L 204.9 208.8 L 208.5 208.8 L 212.1 208.8 L 215.7 208.8 L 219.3 208.8 L 222.9 208.8 L 226.5 208.8 L 230.2 208.8 L 233.8 208.8 L 237.4 208.8 L 241.0 208.8 L 244.6 208.8 L 248.2 208.8 L 251.8 208.8 L 255.4 208.8 L 259.1 208.8 L 262.7 208.8 L 266.3 208.8 L 269.9 208.8 L 273.5 208.8 L 277.1 208.8 L 280.7 208.8 L 284.4 208.8 L 288.0 208.8 L 291.6 208.8 L 295.2 208.8 L 298.8 208.8 L 302.4 215.0 L 306.0 215.0 L 309.6 215.0 L 313.3 215.0 L 316.9 215.0 L 320.5 215.0 L 324.1 215.0 L 327.7 215.0 L 331.3 215.0 L 334.9 215.0 L 338.6 215.0 L 342.2 215.0 L 345.8 225.7 L 349.4 225.7 L 353.0 225.7 L 356.6 225.7 L 360.2 225.7 L 363.8 225.7 L 367.5 225.7 L 371.1 225.7 L 374.7 225.7 L 378.3 225.7 L 381.9 238.5 L 385.5 238.5 L 389.1 238.5 L 392.8 238.5 L 396.4 238.5 L 400.0 238.5 L 403.6 242.1 L 407.2 242.1 L 410.8 242.1 L 414.4 242.1 L 418.1 242.1 L 421.7 242.1 L 425.3 242.1 L 428.9 242.1 L 432.5 242.1 L 436.1 242.1 L 439.7 242.1 L 443.3 242.1 L 447.0 242.1 L 450.6 242.1 L 454.2 242.1 L 457.8 242.1 L 461.4 242.1 L 465.0 242.1 L 468.6 242.1 L 472.3 242.1 L 475.9 242.1 L 479.5 242.1 L 483.1 242.1 L 486.7 242.1 L 490.3 242.1 L 493.9 242.1 L 497.5 242.1 L 501.2 242.1 L 504.8 242.1 L 508.4 242.1 L 512.0 248.2" />
+            <g class="result-objective-baseline"><circle cx="82.0" cy="150.3" r="4.2" /></g>
+            <g class="result-objective-accepted"><circle cx="512.0" cy="248.2" r="4.8" /></g>
+            <text class="result-axis-tick" x="82.0" y="282">0</text>
+            <text class="result-axis-tick" x="226.5" y="282" text-anchor="middle">40</text>
+            <text class="result-axis-tick" x="371.1" y="282" text-anchor="middle">80</text>
+            <text class="result-axis-tick" x="512.0" y="282" text-anchor="end">119</text>
+            <text class="result-axis-label result-x-axis-title" x="297.0" y="306">generation <tspan font-style="italic">k</tspan></text>
+            <text class="result-axis-label result-objective-y-title" x="34" y="164.0" transform="rotate(-90 34 164.0)"><tspan font-style="italic">J</tspan><tspan>(</tspan><tspan font-style="italic">r</tspan><tspan>)</tspan></text>
           </svg>
           <figcaption>Figure 3. Best-so-far score across the curated evolutionary chain, rendered in the same paper style as the quadrature objective trace. Faint points are scored candidates from the sanitized public trace; scores above 16 are clipped at the top of the plotting area.</figcaption>
         </figure>
-<figure class="open-result-primer-card open-result-paper-figure rcpsp-inline-figure rcpsp-benchmark-figure" id="fig-4">
-          <svg class="open-result-primer-svg rcpsp-paper-svg" viewBox="0 0 560 220" role="img" aria-label="Seed versus accepted RCPSP acceptance score readout.">
-            <text class="open-result-axis-label open-result-figure-title" x="48" y="34">Acceptance objective</text>
+<figure class="result-primer-card result-paper-figure rcpsp-inline-figure rcpsp-benchmark-figure" id="fig-4">
+          <svg class="result-primer-svg rcpsp-paper-svg" viewBox="0 0 560 220" role="img" aria-label="Seed versus accepted RCPSP acceptance score readout.">
+            <text class="result-axis-label result-figure-title" x="48" y="34">Acceptance objective</text>
             <text class="rcpsp-paper-note" x="512" y="34" text-anchor="end">lower is better</text>
             <g class="rcpsp-score-readout">
               <path class="rcpsp-reduction-bracket" d="M402.5 64H467.8M402.5 59V69M467.8 59V69" />
@@ -718,25 +718,25 @@ score = mean(g_k) + 0.35 \cdot p95(g_k) + feasibility\_penalty.
               <text class="rcpsp-paper-value" x="512" y="110" text-anchor="end">14.312</text>
               <text class="rcpsp-paper-note" x="402.5" y="140" text-anchor="middle">accepted</text>
               <text class="rcpsp-paper-value" x="402.5" y="158" text-anchor="middle">12.087</text>
-              <path class="open-result-rule-paper-axis" d="M48 176H488" />
-              <text class="open-result-axis-tick" x="48" y="196">0</text>
-              <text class="open-result-axis-tick" x="268.0" y="196" text-anchor="middle">7.5</text>
-              <text class="open-result-axis-tick" x="488.0" y="196" text-anchor="middle">15</text>
+              <path class="result-rule-paper-axis" d="M48 176H488" />
+              <text class="result-axis-tick" x="48" y="196">0</text>
+              <text class="result-axis-tick" x="268.0" y="196" text-anchor="middle">7.5</text>
+              <text class="result-axis-tick" x="488.0" y="196" text-anchor="middle">15</text>
             </g>
           </svg>
           <figcaption>Figure 4. Seed versus accepted acceptance-score readout; lower values are better.</figcaption>
         </figure>
-<figure class="open-result-primer-card open-result-paper-figure rcpsp-inline-figure rcpsp-compression-figure" id="fig-5">
-          <svg class="open-result-primer-svg rcpsp-paper-svg" viewBox="0 0 560 438" role="img" aria-label="Real RCPSP schedule compression and renewable resource load readout for j3025_9.">
-            <text class="open-result-axis-label open-result-figure-title" x="60" y="34">Schedule compression</text>
-            <g class="open-result-objective-legend" transform="translate(60 64)">
+<figure class="result-primer-card result-paper-figure rcpsp-inline-figure rcpsp-compression-figure" id="fig-5">
+          <svg class="result-primer-svg rcpsp-paper-svg" viewBox="0 0 560 438" role="img" aria-label="Real RCPSP schedule compression and renewable resource load readout for j3025_9.">
+            <text class="result-axis-label result-figure-title" x="60" y="34">Schedule compression</text>
+            <g class="result-objective-legend" transform="translate(60 64)">
               <g><rect class="rcpsp-gantt-seed" x="0" y="-8" width="16" height="8" /><text x="24" y="0">seed</text></g>
               <g transform="translate(94 0)"><rect class="rcpsp-accent-fill" x="0" y="-8" width="16" height="8" /><text x="24" y="0">accepted</text></g>
               <g transform="translate(238 0)"><line class="rcpsp-capacity-line" x1="0" y1="-4" x2="28" y2="-4" /><text x="36" y="0">capacity</text></g>
             </g>
             <g class="rcpsp-gantt">
               <text class="rcpsp-paper-section-label" x="60" y="88">all executable jobs (30 bars; 32 including source/sink)</text>
-              <path class="open-result-objective-grid" d="M78 111H500M78 125H500M78 139H500M78 153H500M78 167H500M78 181H500M78 195H500M78 209H500M78 223H500M78 237H500" />
+              <path class="result-objective-grid" d="M78 111H500M78 125H500M78 139H500M78 153H500M78 167H500M78 181H500M78 195H500M78 209H500M78 223H500M78 237H500" />
 <g>
               <rect class="rcpsp-gantt-seed" x="102.6" y="102.0" width="21.1" height="6" />
               <rect class="rcpsp-gantt-accepted" x="78.0" y="98.0" width="21.1" height="8" />
@@ -859,19 +859,19 @@ score = mean(g_k) + 0.35 \cdot p95(g_k) + feasibility\_penalty.
             </g>
               <line class="rcpsp-marker-line rcpsp-accepted-marker" x1="394.5" y1="88.0" x2="394.5" y2="254.0" />
               <line class="rcpsp-marker-line" x1="471.9" y1="88.0" x2="471.9" y2="254.0" />
-              <path class="open-result-rule-paper-axis" d="M78 258H500" />
-              <text class="open-result-axis-tick" x="78.0" y="278" >0</text>
-              <text class="open-result-axis-tick" x="183.5" y="278" text-anchor="middle">30</text>
-              <text class="open-result-axis-tick" x="289.0" y="278" text-anchor="middle">60</text>
-              <text class="open-result-axis-tick" x="394.5" y="278" text-anchor="middle">90</text>
-              <text class="open-result-axis-tick" x="500.0" y="278" text-anchor="end">120</text>
+              <path class="result-rule-paper-axis" d="M78 258H500" />
+              <text class="result-axis-tick" x="78.0" y="278" >0</text>
+              <text class="result-axis-tick" x="183.5" y="278" text-anchor="middle">30</text>
+              <text class="result-axis-tick" x="289.0" y="278" text-anchor="middle">60</text>
+              <text class="result-axis-tick" x="394.5" y="278" text-anchor="middle">90</text>
+              <text class="result-axis-tick" x="500.0" y="278" text-anchor="end">120</text>
               <text class="rcpsp-paper-note" x="394.5" y="296" text-anchor="middle">accepted Cmax</text>
               <text class="rcpsp-paper-note" x="471.9" y="296" text-anchor="middle">seed Cmax</text>
             </g>
             <g>
               <text class="rcpsp-paper-section-label" x="60" y="304">Resource 3 full-instance load</text>
-              <path class="open-result-rule-paper-axis" d="M78 324V402H500" />
-              <path class="open-result-objective-grid" d="M78 324H500" />
+              <path class="result-rule-paper-axis" d="M78 324V402H500" />
+              <path class="result-objective-grid" d="M78 324H500" />
               <path class="rcpsp-capacity-line" d="M78 324H500" />
               <text class="rcpsp-paper-note" x="500" y="316" text-anchor="end">capacity 14</text>
 <g>
@@ -922,20 +922,20 @@ score = mean(g_k) + 0.35 \cdot p95(g_k) + feasibility\_penalty.
               <rect class="rcpsp-load" x="467.8" y="402.0" width="29.2" height="0.0" />
               <rect class="rcpsp-load-seed" x="467.8" y="357.4" width="29.2" height="44.6" />
             </g>
-              <text class="open-result-axis-tick" x="68" y="405" text-anchor="end">0</text>
-              <text class="open-result-axis-tick" x="68" y="327" text-anchor="end">cap</text>
-              <text class="open-result-axis-tick" x="78" y="422">0</text>
-              <text class="open-result-axis-tick" x="289" y="422" text-anchor="middle">time</text>
-              <text class="open-result-axis-tick" x="500" y="422" text-anchor="end">120</text>
-              <text class="open-result-axis-label open-result-objective-y-title" x="28" y="363" transform="rotate(-90 28 363)">demand</text>
+              <text class="result-axis-tick" x="68" y="405" text-anchor="end">0</text>
+              <text class="result-axis-tick" x="68" y="327" text-anchor="end">cap</text>
+              <text class="result-axis-tick" x="78" y="422">0</text>
+              <text class="result-axis-tick" x="289" y="422" text-anchor="middle">time</text>
+              <text class="result-axis-tick" x="500" y="422" text-anchor="end">120</text>
+              <text class="result-axis-label result-objective-y-title" x="28" y="363" transform="rotate(-90 28 363)">demand</text>
             </g>
           </svg>
           <figcaption>Figure 5. Real schedule-compression readout for PSPLIB J30 instance j3025_9. All executable jobs are rendered as unlabeled bars; seed finishes at 112, accepted at 90, and the proven optimum is 84.</figcaption>
         </figure>
 <p>Figure 5 translates the aggregate result into one real portfolio instance, <code>j3025_9</code>. Unlike the introductory schematic, it uses all executable jobs from the instance and the same instance's renewable-resource load buckets.</p>
-<figure class="open-result-paper-table" id="table-2">
-          <div class="open-result-table-wrap">
-            <table class="open-result-table">
+<figure class="result-paper-table" id="table-2">
+          <div class="result-table-wrap">
+            <table class="result-table">
               <thead>
                 <tr>
                   <th>Metric</th>
@@ -969,9 +969,9 @@ score = mean(g_k) + 0.35 \cdot p95(g_k) + feasibility\_penalty.
           <figcaption>Table 2. Reported score comparison across the curated evolutionary chain; lower values are better.</figcaption>
         </figure>
 <p>Figure 6 keeps the accepted-candidate diagnostics separate from the chain objective. In absolute benchmark terms, this is not a 99% approximation claim: the mean accepted makespan is about 106.04% of the proven optimum, or roughly 94.31% if expressed as optimum divided by candidate makespan.</p>
-<figure class="open-result-primer-card open-result-paper-figure rcpsp-inline-figure rcpsp-gap-figure" id="fig-6">
-          <svg class="open-result-primer-svg rcpsp-paper-svg" viewBox="0 0 560 280" role="img" aria-label="Accepted RCPSP gap diagnostics.">
-            <text class="open-result-axis-label open-result-figure-title" x="72" y="34">Accepted candidate diagnostics</text>
+<figure class="result-primer-card result-paper-figure rcpsp-inline-figure rcpsp-gap-figure" id="fig-6">
+          <svg class="result-primer-svg rcpsp-paper-svg" viewBox="0 0 560 280" role="img" aria-label="Accepted RCPSP gap diagnostics.">
+            <text class="result-axis-label result-figure-title" x="72" y="34">Accepted candidate diagnostics</text>
             <text class="rcpsp-paper-note" x="488" y="34" text-anchor="end">80 frozen PSPLIB J30 instances</text>
 <g>
               <text class="rcpsp-paper-section-label" x="72" y="76">Mean gap</text>
@@ -1002,12 +1002,12 @@ score = mean(g_k) + 0.35 \cdot p95(g_k) + feasibility\_penalty.
           <figcaption>Figure 6. Accepted candidate diagnostics on the frozen 80-instance portfolio.</figcaption>
         </figure>
 <p>The worst residual gaps remain visible because they matter operationally. Figure 7 is the tail readout: it shows the largest accepted-candidate residual gaps and their makespan-versus-optimum comparison.</p>
-<figure class="open-result-primer-card open-result-paper-figure rcpsp-inline-figure rcpsp-tail-figure" id="fig-7">
-          <svg class="open-result-primer-svg rcpsp-paper-svg" viewBox="0 0 560 328" role="img" aria-label="Worst accepted RCPSP gaps.">
-            <text class="open-result-axis-label open-result-figure-title" x="72" y="34">Tail behavior kept visible</text>
+<figure class="result-primer-card result-paper-figure rcpsp-inline-figure rcpsp-tail-figure" id="fig-7">
+          <svg class="result-primer-svg rcpsp-paper-svg" viewBox="0 0 560 328" role="img" aria-label="Worst accepted RCPSP gaps.">
+            <text class="result-axis-label result-figure-title" x="72" y="34">Tail behavior kept visible</text>
             <text class="rcpsp-paper-note" x="488" y="34" text-anchor="end">largest accepted-candidate gaps</text>
-            <path class="open-result-rule-paper-axis" d="M170 50V250H512" />
-            <path class="open-result-objective-grid" d="M270 50V250M370 50V250M470 50V250" />
+            <path class="result-rule-paper-axis" d="M170 50V250H512" />
+            <path class="result-objective-grid" d="M270 50V250M370 50V250M470 50V250" />
 <g>
               <text class="rcpsp-paper-section-label" x="72" y="74">j3025_10</text>
               <rect class="rcpsp-accent-fill" x="170" y="62" width="280.2" height="13" />
@@ -1048,10 +1048,10 @@ score = mean(g_k) + 0.35 \cdot p95(g_k) + feasibility\_penalty.
               <rect class="rcpsp-accent-fill" x="170" y="223" width="205.5" height="13" />
               <text class="rcpsp-paper-value" x="385.5" y="235">16.44% | 85 vs 73</text>
             </g>
-            <text class="open-result-axis-tick" x="170" y="276">0%</text>
-            <text class="open-result-axis-tick" x="270" y="276">8%</text>
-            <text class="open-result-axis-tick" x="370" y="276">16%</text>
-            <text class="open-result-axis-tick" x="470" y="276">24%</text>
+            <text class="result-axis-tick" x="170" y="276">0%</text>
+            <text class="result-axis-tick" x="270" y="276">8%</text>
+            <text class="result-axis-tick" x="370" y="276">16%</text>
+            <text class="result-axis-tick" x="470" y="276">24%</text>
             <text class="rcpsp-paper-note" x="72" y="306">Worst residual gaps remain part of the public result definition.</text>
           </svg>
           <figcaption>Figure 7. Worst-instance tail behavior for the accepted candidate. Each bar shows residual gap against the proven optimum.</figcaption>

--- a/styles.css
+++ b/styles.css
@@ -804,18 +804,18 @@ a {
   margin-bottom: 0;
 }
 
-.open-result-card {
+.result-card {
   position: relative;
   min-height: clamp(34rem, 48vw, 44rem);
   overflow: hidden;
   border-right: 1px solid var(--line);
 }
 
-.open-result-card:last-child {
+.result-card:last-child {
   border-right: 0;
 }
 
-.open-result-link {
+.result-link {
   display: grid;
   grid-template-rows: minmax(0, 1fr) auto auto auto;
   position: relative;
@@ -827,36 +827,36 @@ a {
   text-decoration: none;
 }
 
-.open-result-link:hover {
+.result-link:hover {
   text-decoration: none;
 }
 
-.open-result-link:focus-visible {
+.result-link:focus-visible {
   outline: 2px solid var(--focus-ring);
   outline-offset: -2px;
 }
 
-.open-result-link > h2,
-.open-result-link > p,
-.open-result-link > .open-result-measure,
-.open-result-link > .open-result-meta {
+.result-link > h2,
+.result-link > p,
+.result-link > .result-measure,
+.result-link > .result-meta {
   position: relative;
   z-index: 1;
 }
 
-.open-result-link > h2 {
+.result-link > h2 {
   grid-row: 2;
 }
 
-.open-result-link > p {
+.result-link > p {
   grid-row: 3;
 }
 
-.open-result-link > .open-result-measure {
+.result-link > .result-measure {
   grid-row: 4;
 }
 
-.open-result-meta {
+.result-meta {
   display: flex;
   position: absolute;
   align-items: flex-start;
@@ -867,17 +867,17 @@ a {
   pointer-events: none;
 }
 
-.open-result-meta .eyebrow {
+.result-meta .eyebrow {
   margin: 0;
 }
 
-.open-result-meta span {
+.result-meta span {
   color: var(--muted);
   font-size: 0.92rem;
   letter-spacing: -0.01em;
 }
 
-.open-result-card h2 {
+.result-card h2 {
   max-width: 11ch;
   margin: 0;
   font-size: clamp(2.8rem, 5.6vw, 5.4rem);
@@ -886,7 +886,7 @@ a {
   letter-spacing: 0;
 }
 
-.open-result-card p {
+.result-card p {
   max-width: 38ch;
   margin: 1.35rem 0 0;
   color: var(--muted-soft);
@@ -896,21 +896,21 @@ a {
   letter-spacing: -0.01em;
 }
 
-.open-result-card--quadrature p {
+.result-card--quadrature p {
   max-width: 34ch;
 }
 
-.open-result-card--rcpsp h2 {
+.result-card--rcpsp h2 {
   max-width: 14ch;
   font-size: clamp(2.8rem, 5.2vw, 5.1rem);
   letter-spacing: 0;
 }
 
-.open-result-card--rcpsp p {
+.result-card--rcpsp p {
   max-width: 36ch;
 }
 
-.open-result-card-visual {
+.result-card-visual {
   position: absolute;
   right: clamp(-8rem, -5vw, -2.5rem);
   bottom: clamp(5.6rem, 8vw, 8.2rem);
@@ -922,54 +922,54 @@ a {
   pointer-events: none;
 }
 
-.open-result-card-chart line,
-.open-result-card-chart path {
+.result-card-chart line,
+.result-card-chart path {
   vector-effect: non-scaling-stroke;
 }
 
-.open-result-card-chart > line {
+.result-card-chart > line {
   stroke: color-mix(in srgb, var(--text) 24%, transparent);
   stroke-width: 1.2;
 }
 
-.open-result-card-chart .grid {
+.result-card-chart .grid {
   stroke: color-mix(in srgb, var(--text) 12%, transparent);
 }
 
-.open-result-card-chart .area {
+.result-card-chart .area {
   fill: rgba(11, 132, 254, 0.13);
 }
 
-.open-result-card-chart .hatch {
+.result-card-chart .hatch {
   fill: url(#quadrature-card-hatch);
   opacity: 0.42;
 }
 
-.open-result-card-chart .hatch line,
-.open-result-card-visual pattern line {
+.result-card-chart .hatch line,
+.result-card-visual pattern line {
   stroke: color-mix(in srgb, var(--text) 34%, transparent);
   stroke-width: 1;
 }
 
-.open-result-card-chart .curve {
+.result-card-chart .curve {
   fill: none;
   stroke: color-mix(in srgb, var(--text) 84%, transparent);
   stroke-width: 3.2;
   stroke-linecap: round;
 }
 
-.open-result-card-chart .nodes line {
+.result-card-chart .nodes line {
   stroke: rgba(11, 132, 254, 0.72);
   stroke-width: 1.8;
 }
 
-.open-result-card-chart .nodes circle {
+.result-card-chart .nodes circle {
   fill: var(--bg);
   stroke: var(--accent);
   stroke-width: 3.2;
 }
 
-.open-result-card--rcpsp .open-result-card-visual {
+.result-card--rcpsp .result-card-visual {
   right: clamp(-8rem, -5vw, -2.5rem);
   bottom: clamp(5.6rem, 8vw, 8.2rem);
   width: min(62%, 38rem);
@@ -977,51 +977,51 @@ a {
   opacity: 0.38;
 }
 
-.open-result-card-rcpsp line,
-.open-result-card-rcpsp path,
-.open-result-card-rcpsp rect,
-.open-result-card-rcpsp circle {
+.result-card-rcpsp line,
+.result-card-rcpsp path,
+.result-card-rcpsp rect,
+.result-card-rcpsp circle {
   vector-effect: non-scaling-stroke;
 }
 
-.open-result-card-rcpsp .lane {
+.result-card-rcpsp .lane {
   stroke: color-mix(in srgb, var(--text) 16%, transparent);
   stroke-width: 1;
 }
 
-.open-result-card-rcpsp .axis {
+.result-card-rcpsp .axis {
   fill: none;
   stroke: color-mix(in srgb, var(--text) 36%, transparent);
   stroke-width: 1.3;
 }
 
-.open-result-card-rcpsp .seed-bars rect,
-.open-result-card-rcpsp .load .seed {
+.result-card-rcpsp .seed-bars rect,
+.result-card-rcpsp .load .seed {
   fill: color-mix(in srgb, var(--text) 22%, transparent);
   stroke: color-mix(in srgb, var(--text) 46%, transparent);
   stroke-width: 1.1;
 }
 
-.open-result-card-rcpsp .accepted-bars rect,
-.open-result-card-rcpsp .load .accepted {
+.result-card-rcpsp .accepted-bars rect,
+.result-card-rcpsp .load .accepted {
   fill: color-mix(in srgb, var(--accent) 72%, transparent);
   stroke: color-mix(in srgb, var(--accent) 86%, transparent);
   stroke-width: 1.1;
 }
 
-.open-result-card-rcpsp .cmax {
+.result-card-rcpsp .cmax {
   stroke-width: 2;
 }
 
-.open-result-card-rcpsp .cmax.accepted {
+.result-card-rcpsp .cmax.accepted {
   stroke: var(--accent);
 }
 
-.open-result-card-rcpsp .cmax.seed {
+.result-card-rcpsp .cmax.seed {
   stroke: color-mix(in srgb, var(--text) 70%, transparent);
 }
 
-.open-result-card-rcpsp .capacity {
+.result-card-rcpsp .capacity {
   fill: none;
   stroke: color-mix(in srgb, var(--text) 64%, transparent);
   stroke-dasharray: 8 8;
@@ -1029,7 +1029,7 @@ a {
   stroke-width: 1.5;
 }
 
-.open-result-measure {
+.result-measure {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 0.55rem 1rem;
@@ -1039,20 +1039,20 @@ a {
   border-top: 1px solid var(--line);
 }
 
-.open-result-measure span {
+.result-measure span {
   color: var(--muted);
   font-size: 0.82rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
 
-.open-result-measure strong {
+.result-measure strong {
   font-size: 1.08rem;
   font-weight: 500;
   letter-spacing: -0.02em;
 }
 
-.open-result-card:hover {
+.result-card:hover {
   background: var(--accent-soft);
 }
 
@@ -1061,33 +1061,33 @@ a {
     grid-template-columns: 1fr;
   }
 
-  .open-result-card {
+  .result-card {
     min-height: clamp(30rem, 70vw, 38rem);
     border-right: 0;
     border-bottom: 1px solid var(--line);
   }
 
-  .open-result-card:last-child {
+  .result-card:last-child {
     border-bottom: 0;
   }
 
-  .open-result-card--rcpsp .open-result-card-visual {
+  .result-card--rcpsp .result-card-visual {
     right: clamp(-8rem, -5vw, -2.5rem);
     bottom: clamp(5.6rem, 8vw, 8.2rem);
     width: min(62%, 38rem);
   }
 }
 
-.open-result-detail {
+.result-detail {
   padding: clamp(2.4rem, 6vw, 5rem) var(--content-gutter);
   border-top: 1px solid var(--line);
 }
 
-.open-result-detail-hero .eyebrow {
+.result-detail-hero .eyebrow {
   margin: 0 0 1.1rem;
 }
 
-.open-result-snapshot {
+.result-snapshot {
   display: grid;
   grid-template-columns: minmax(18rem, 0.9fr) minmax(0, 1.1fr);
   gap: 0;
@@ -1097,7 +1097,7 @@ a {
   text-align: left;
 }
 
-.open-result-snapshot-primary {
+.result-snapshot-primary {
   display: grid;
   min-height: 16rem;
   padding: clamp(1.2rem, 2.5vw, 1.8rem);
@@ -1105,8 +1105,8 @@ a {
   align-content: space-between;
 }
 
-.open-result-snapshot-primary span,
-.open-result-snapshot-cards span {
+.result-snapshot-primary span,
+.result-snapshot-cards span {
   color: var(--muted);
   font-size: 0.78rem;
   font-weight: 600;
@@ -1114,7 +1114,7 @@ a {
   text-transform: uppercase;
 }
 
-.open-result-snapshot-primary strong {
+.result-snapshot-primary strong {
   display: block;
   margin-top: 1.1rem;
   color: var(--text);
@@ -1124,7 +1124,7 @@ a {
   letter-spacing: -0.08em;
 }
 
-.open-result-snapshot-primary p {
+.result-snapshot-primary p {
   max-width: 34rem;
   margin: 1.2rem 0 0;
   color: var(--muted-soft);
@@ -1134,12 +1134,12 @@ a {
   letter-spacing: -0.01em;
 }
 
-.open-result-snapshot-cards {
+.result-snapshot-cards {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
-.open-result-snapshot-cards div {
+.result-snapshot-cards div {
   display: grid;
   min-height: 8rem;
   padding: clamp(1rem, 2vw, 1.35rem);
@@ -1148,15 +1148,15 @@ a {
   align-content: space-between;
 }
 
-.open-result-snapshot-cards div:nth-child(2n) {
+.result-snapshot-cards div:nth-child(2n) {
   border-right: 0;
 }
 
-.open-result-snapshot-cards div:nth-last-child(-n + 2) {
+.result-snapshot-cards div:nth-last-child(-n + 2) {
   border-bottom: 0;
 }
 
-.open-result-snapshot-cards strong {
+.result-snapshot-cards strong {
   color: var(--text);
   font-size: clamp(1.55rem, 3vw, 2.65rem);
   font-weight: 500;
@@ -1164,7 +1164,7 @@ a {
   letter-spacing: -0.05em;
 }
 
-.open-result-primer {
+.result-primer {
   display: grid;
   grid-template-columns: minmax(20rem, 0.34fr) minmax(0, 1fr);
   gap: clamp(2rem, 5vw, 5rem);
@@ -1173,15 +1173,15 @@ a {
   border-bottom: 1px solid var(--line);
 }
 
-.open-result-primer-copy {
+.result-primer-copy {
   align-self: center;
 }
 
-.open-result-primer-copy .eyebrow {
+.result-primer-copy .eyebrow {
   margin: 0 0 1rem;
 }
 
-.open-result-primer-copy h2 {
+.result-primer-copy h2 {
   max-width: 13ch;
   margin: 0;
   color: var(--text);
@@ -1191,7 +1191,7 @@ a {
   letter-spacing: -0.06em;
 }
 
-.open-result-primer-copy p {
+.result-primer-copy p {
   max-width: 39rem;
   margin: 1.2rem 0 0;
   color: var(--muted-soft);
@@ -1201,14 +1201,14 @@ a {
   letter-spacing: -0.01em;
 }
 
-.open-result-primer-panel {
+.result-primer-panel {
   display: grid;
   gap: 0;
   border: 1px solid var(--line);
   min-height: 23rem;
 }
 
-.open-result-primer-card {
+.result-primer-card {
   display: grid;
   gap: 0.2rem;
   width: min(100%, 48rem);
@@ -1216,7 +1216,7 @@ a {
   border: 0;
 }
 
-.open-result-primer-card figcaption {
+.result-primer-card figcaption {
   max-width: 38rem;
   margin: 0 auto;
   padding: 0;
@@ -1229,7 +1229,7 @@ a {
   text-align: center;
 }
 
-.open-result-primer-card figcaption span {
+.result-primer-card figcaption span {
   color: var(--muted);
   font-size: 0.78rem;
   font-weight: 600;
@@ -1237,7 +1237,7 @@ a {
   text-transform: uppercase;
 }
 
-.open-result-primer-card figcaption strong {
+.result-primer-card figcaption strong {
   max-width: 16ch;
   color: var(--text);
   font-size: clamp(1.28rem, 2.3vw, 2rem);
@@ -1246,7 +1246,7 @@ a {
   letter-spacing: -0.04em;
 }
 
-.open-result-primer-svg {
+.result-primer-svg {
   --figure-area-fill: color-mix(in srgb, var(--accent) 18%, transparent);
   --figure-area-stroke: color-mix(in srgb, var(--accent) 58%, transparent);
   --figure-reference-fill: color-mix(in srgb, var(--text) 8%, transparent);
@@ -1259,340 +1259,340 @@ a {
   color: var(--accent);
 }
 
-.open-result-primer-svg text {
+.result-primer-svg text {
   fill: var(--muted);
   font-family: Georgia, "Times New Roman", serif;
   font-size: 12px;
   letter-spacing: 0;
 }
 
-.open-result-primer-grid {
+.result-primer-grid {
   fill: none;
   stroke: color-mix(in srgb, var(--text) 48%, transparent);
   stroke-width: 1;
 }
 
-.open-result-primer-area {
+.result-primer-area {
   fill: var(--figure-area-fill);
 }
 
-.open-result-integral-hatch {
+.result-integral-hatch {
   fill: url("#conceptExactIntegralHatch");
   opacity: 0.92;
 }
 
-.open-result-primer-svg pattern line {
+.result-primer-svg pattern line {
   stroke: color-mix(in srgb, var(--text) 38%, transparent);
   stroke-width: 0.9;
 }
 
-.open-result-primer-curve {
+.result-primer-curve {
   fill: none;
   stroke: var(--text);
   stroke-width: 2.4;
   stroke-linecap: round;
 }
 
-.open-result-primer-curve.muted-curve {
+.result-primer-curve.muted-curve {
   stroke: color-mix(in srgb, var(--text) 52%, transparent);
   stroke-width: 2;
 }
 
-.open-result-primer-curve.dashed-curve {
+.result-primer-curve.dashed-curve {
   stroke-dasharray: 7 7;
 }
 
-.open-result-axis-label,
-.open-result-axis-tick {
+.result-axis-label,
+.result-axis-tick {
   fill: var(--muted);
 }
 
-.open-result-axis-tick {
+.result-axis-tick {
   font-family: "Times New Roman", Georgia, serif;
   font-variant-numeric: lining-nums tabular-nums;
   text-anchor: middle;
 }
 
-.open-result-x-axis-title {
+.result-x-axis-title {
   text-anchor: middle;
 }
 
-.open-result-y-axis-title {
+.result-y-axis-title {
   font-size: 11px;
 }
 
-.open-result-figure-title {
+.result-figure-title {
   fill: var(--text);
   font-size: 13px;
   font-style: italic;
 }
 
-.open-result-panel-subtitle {
+.result-panel-subtitle {
   fill: var(--muted);
   font-size: 10px;
   font-style: italic;
 }
 
-.open-result-interval-label {
+.result-interval-label {
   fill: var(--muted);
 }
 
-.open-result-interval-bracket {
+.result-interval-bracket {
   fill: none;
   stroke: var(--line-strong);
   stroke-width: 1;
 }
 
-.open-result-axis-notch {
+.result-axis-notch {
   fill: none;
   stroke: var(--line-strong);
   stroke-width: 1;
 }
 
-.open-result-primer-nodes line {
+.result-primer-nodes line {
   stroke: var(--text);
   stroke-width: 2;
 }
 
-.open-result-primer-nodes circle {
+.result-primer-nodes circle {
   fill: var(--bg);
   stroke: var(--accent);
   stroke-width: 2;
 }
 
-.open-result-primer-nodes text {
+.result-primer-nodes text {
   text-anchor: middle;
   fill: var(--text);
   font-size: 12px;
 }
 
-.open-result-rough-rect rect {
+.result-rough-rect rect {
   fill: var(--figure-area-fill);
   stroke: color-mix(in srgb, var(--text) 50%, transparent);
   stroke-width: 1;
 }
 
-.open-result-rough-rect .open-result-rough-hatch {
+.result-rough-rect .result-rough-hatch {
   fill: url("#roughRectangleHatch");
   opacity: 0.72;
   stroke: none;
 }
 
-.open-result-rough-rect line {
+.result-rough-rect line {
   stroke: color-mix(in srgb, var(--text) 70%, transparent);
   stroke-width: 1.5;
 }
 
-.open-result-rough-rect circle {
+.result-rough-rect circle {
   fill: var(--bg);
   stroke: var(--accent);
   stroke-width: 2;
 }
 
-.open-result-concept-sample rect:first-child {
+.result-concept-sample rect:first-child {
   fill: var(--figure-area-fill);
   stroke: var(--figure-area-stroke);
   stroke-width: 0.8;
 }
 
-.open-result-concept-sample-hatches {
+.result-concept-sample-hatches {
   pointer-events: none;
 }
 
-.open-result-concept-sample-hatches .open-result-concept-sample rect:first-child {
+.result-concept-sample-hatches .result-concept-sample rect:first-child {
   fill: url("#conceptQuadratureHatch");
   opacity: 0.86;
   stroke: none;
 }
 
-.open-result-concept-sample-hatches .open-result-concept-sample line,
-.open-result-concept-sample-hatches .open-result-concept-sample circle {
+.result-concept-sample-hatches .result-concept-sample line,
+.result-concept-sample-hatches .result-concept-sample circle {
   display: none;
 }
 
-.open-result-concept-sample line {
+.result-concept-sample line {
   stroke: color-mix(in srgb, var(--text) 54%, transparent);
   stroke-width: 1.2;
 }
 
-.open-result-concept-sample circle {
+.result-concept-sample circle {
   fill: var(--bg);
   stroke: color-mix(in srgb, var(--text) 58%, transparent);
   stroke-width: 1.7;
 }
 
-.open-result-concept-sample.is-accepted circle,
-.open-result-concept-samples .open-result-concept-sample circle {
+.result-concept-sample.is-accepted circle,
+.result-concept-samples .result-concept-sample circle {
   stroke: var(--accent);
 }
 
-.open-result-concept-samples-muted .open-result-concept-sample rect:first-child,
-.open-result-concept-samples-muted .open-result-concept-sample line,
-.open-result-concept-samples-muted .open-result-concept-sample circle {
+.result-concept-samples-muted .result-concept-sample rect:first-child,
+.result-concept-samples-muted .result-concept-sample line,
+.result-concept-samples-muted .result-concept-sample circle {
   opacity: 0.34;
 }
 
-.open-result-concept-samples-muted .open-result-concept-sample rect:first-child {
+.result-concept-samples-muted .result-concept-sample rect:first-child {
   fill: var(--figure-reference-fill);
   stroke: var(--figure-reference-stroke);
 }
 
-.open-result-rough-rectangles-muted .open-result-rough-rect rect {
+.result-rough-rectangles-muted .result-rough-rect rect {
   fill: var(--figure-reference-fill);
   stroke: var(--figure-reference-stroke);
 }
 
-.open-result-rough-rectangles-muted .open-result-rough-rect .open-result-rough-hatch {
+.result-rough-rectangles-muted .result-rough-rect .result-rough-hatch {
   fill: url("#roughRectangleHatch");
   opacity: 0.28;
   stroke: none;
 }
 
-.open-result-rough-rectangles-muted .open-result-rough-rect line,
-.open-result-rough-rectangles-muted .open-result-rough-rect circle {
+.result-rough-rectangles-muted .result-rough-rect line,
+.result-rough-rectangles-muted .result-rough-rect circle {
   opacity: 0.45;
 }
 
-.open-result-residual-region {
+.result-residual-region {
   fill: var(--figure-area-fill);
   stroke: var(--figure-area-stroke);
   stroke-width: 0.8;
   opacity: 0.78;
 }
 
-.open-result-residual-region.open-result-residual-negative {
+.result-residual-region.result-residual-negative {
   fill: var(--figure-area-fill);
   stroke: var(--figure-area-stroke);
 }
 
-.open-result-residual-region.open-result-residual-positive {
+.result-residual-region.result-residual-positive {
   fill: var(--figure-area-fill);
   stroke: var(--figure-area-stroke);
 }
 
-.open-result-residual-hatch {
+.result-residual-hatch {
   fill: url("#conceptResidualHatch");
   opacity: 0.78;
   stroke: none;
 }
 
-.open-result-residual-location-svg .open-result-primer-grid,
-.open-result-objective-svg .open-result-rule-paper-axis {
+.result-residual-location-svg .result-primer-grid,
+.result-objective-svg .result-rule-paper-axis {
   stroke: color-mix(in srgb, var(--text) 42%, transparent);
 }
 
-.open-result-residual-cell rect {
+.result-residual-cell rect {
   fill: var(--figure-reference-fill);
   stroke: var(--figure-reference-stroke);
   stroke-width: 0.8;
 }
 
-.open-result-residual-cell-gap-fill {
+.result-residual-cell-gap-fill {
   fill: var(--figure-area-fill);
   stroke: var(--figure-area-stroke);
   stroke-width: 0.7;
 }
 
-.open-result-residual-cell circle {
+.result-residual-cell circle {
   fill: var(--bg);
   stroke: var(--accent);
   stroke-width: 1.8;
 }
 
-.open-result-residual-location-svg pattern line {
+.result-residual-location-svg pattern line {
   stroke: color-mix(in srgb, var(--text) 38%, transparent);
 }
 
-.open-result-residual-cell-gap {
+.result-residual-cell-gap {
   fill: url("#acceptedResidualHatch");
   opacity: 0.88;
   stroke: none;
 }
 
-.open-result-residual-value {
+.result-residual-value {
   font-size: 10px;
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
 
-.open-result-residual-number {
+.result-residual-number {
   fill: var(--text);
   font-size: 14px;
   font-variant-numeric: tabular-nums;
 }
 
-.open-result-residual-number-baseline {
+.result-residual-number-baseline {
   fill: var(--muted);
 }
 
-.open-result-residual-baseline-marker line {
+.result-residual-baseline-marker line {
   stroke: color-mix(in srgb, var(--text) 54%, transparent);
   stroke-width: 1.1;
 }
 
-.open-result-residual-baseline-marker circle {
+.result-residual-baseline-marker circle {
   fill: var(--bg);
   stroke: color-mix(in srgb, var(--text) 58%, transparent);
   stroke-width: 1.7;
 }
 
-.open-result-comparison-value {
+.result-comparison-value {
   fill: var(--muted);
   font-size: 10.5px;
   font-variant-numeric: tabular-nums;
 }
 
-.open-result-objective-grid {
+.result-objective-grid {
   fill: none;
   stroke: color-mix(in srgb, var(--text) 16%, transparent);
   stroke-width: 0.8;
 }
 
-.open-result-objective-x-tick {
+.result-objective-x-tick {
   fill: none;
   stroke: color-mix(in srgb, var(--text) 42%, transparent);
   stroke-width: 0.8;
 }
 
-.open-result-objective-y-label {
+.result-objective-y-label {
   text-anchor: end;
 }
 
-.open-result-objective-y-title {
+.result-objective-y-title {
   text-anchor: middle;
 }
 
-.open-result-objective-direction {
+.result-objective-direction {
   font-size: 11px;
   font-style: italic;
   text-anchor: end;
 }
 
-.open-result-objective-legend text {
+.result-objective-legend text {
   fill: var(--muted);
   font-family: Georgia, "Times New Roman", serif;
   font-size: 9.8px;
 }
 
-.open-result-objective-legend-proposal {
+.result-objective-legend-proposal {
   fill: color-mix(in srgb, var(--text) 34%, transparent);
 }
 
-.open-result-objective-legend-best {
+.result-objective-legend-best {
   stroke: var(--text);
   stroke-linecap: round;
   stroke-width: 2;
 }
 
-.open-result-objective-proposal {
+.result-objective-proposal {
   fill: color-mix(in srgb, var(--text) 30%, transparent);
 }
 
-.open-result-objective-proposal.is-clipped {
+.result-objective-proposal.is-clipped {
   fill: color-mix(in srgb, var(--text) 18%, transparent);
 }
 
-.open-result-objective-best {
+.result-objective-best {
   fill: none;
   stroke: var(--text);
   stroke-width: 2.2;
@@ -1600,13 +1600,13 @@ a {
   stroke-linejoin: round;
 }
 
-.open-result-objective-accepted circle {
+.result-objective-accepted circle {
   fill: var(--bg);
   stroke: var(--accent);
   stroke-width: 2.2;
 }
 
-.open-result-objective-accepted text {
+.result-objective-accepted text {
   fill: var(--text);
   font-family: Georgia, "Times New Roman", serif;
   font-size: 12px;
@@ -1614,37 +1614,37 @@ a {
   text-anchor: middle;
 }
 
-.open-result-objective-baseline circle {
+.result-objective-baseline circle {
   fill: var(--bg);
   stroke: color-mix(in srgb, var(--text) 55%, transparent);
   stroke-width: 1.8;
 }
 
-.open-result-objective-baseline text {
+.result-objective-baseline text {
   fill: var(--muted);
   font-family: Georgia, "Times New Roman", serif;
   font-size: 12px;
   font-style: italic;
 }
 
-.open-result-primer-bar {
+.result-primer-bar {
   fill: color-mix(in srgb, var(--accent) 32%, transparent);
   stroke: var(--accent);
   stroke-width: 1;
 }
 
-.open-result-primer-bar.estimate-bar {
+.result-primer-bar.estimate-bar {
   fill: color-mix(in srgb, var(--text) 18%, transparent);
   stroke: var(--text);
 }
 
-.open-result-primer-error-line {
+.result-primer-error-line {
   stroke: var(--accent);
   stroke-width: 3;
   stroke-linecap: round;
 }
 
-.open-result-primer-error-zoom {
+.result-primer-error-zoom {
   fill: var(--accent);
   opacity: 0.8;
 }
@@ -1774,7 +1774,7 @@ a {
   font-weight: 600;
 }
 
-.rcpsp-paper-svg .rcpsp-gantt .open-result-axis-tick,
+.rcpsp-paper-svg .rcpsp-gantt .result-axis-tick,
 .rcpsp-paper-svg .rcpsp-gantt .rcpsp-paper-note {
   fill: var(--muted);
   font-weight: 400;
@@ -1809,7 +1809,7 @@ a {
   stroke-width: 1.4;
 }
 
-.open-result-rule-visual {
+.result-rule-visual {
   display: grid;
   grid-template-columns: minmax(20rem, 0.34fr) minmax(0, 1fr);
   gap: clamp(2rem, 5vw, 5rem);
@@ -1818,15 +1818,15 @@ a {
   border-bottom: 1px solid var(--line);
 }
 
-.open-result-rule-copy {
+.result-rule-copy {
   align-self: center;
 }
 
-.open-result-rule-copy .eyebrow {
+.result-rule-copy .eyebrow {
   margin: 0 0 1rem;
 }
 
-.open-result-rule-copy h2 {
+.result-rule-copy h2 {
   max-width: 11ch;
   margin: 0;
   color: var(--text);
@@ -1836,7 +1836,7 @@ a {
   letter-spacing: -0.06em;
 }
 
-.open-result-rule-copy p:not(.eyebrow) {
+.result-rule-copy p:not(.eyebrow) {
   max-width: 38rem;
   margin: 1.2rem 0 0;
   color: var(--muted-soft);
@@ -1846,19 +1846,19 @@ a {
   letter-spacing: -0.01em;
 }
 
-.open-result-rule-panel {
+.result-rule-panel {
   display: grid;
   min-height: clamp(24rem, 35vw, 33rem);
   border: 1px solid var(--line);
 }
 
-.open-result-rule-axis {
+.result-rule-axis {
   position: relative;
   min-height: 22rem;
   padding: clamp(1.2rem, 2vw, 1.6rem);
 }
 
-.open-result-axis-line {
+.result-axis-line {
   position: absolute;
   right: clamp(3rem, 5vw, 4.5rem);
   bottom: 34%;
@@ -1867,7 +1867,7 @@ a {
   background: var(--line-strong);
 }
 
-.open-result-axis-end {
+.result-axis-end {
   position: absolute;
   bottom: calc(34% - 0.55rem);
   color: var(--muted);
@@ -1875,15 +1875,15 @@ a {
   font-size: 0.82rem;
 }
 
-.open-result-axis-start {
+.result-axis-start {
   left: clamp(1.2rem, 2vw, 1.6rem);
 }
 
-.open-result-axis-finish {
+.result-axis-finish {
   right: clamp(1.2rem, 2vw, 1.6rem);
 }
 
-.open-result-node {
+.result-node {
   position: absolute;
   bottom: 38%;
   left: var(--x);
@@ -1892,7 +1892,7 @@ a {
   transform: translateX(-50%);
 }
 
-.open-result-node::before {
+.result-node::before {
   content: "";
   width: 2px;
   height: var(--bar);
@@ -1900,7 +1900,7 @@ a {
   transform: translateY(-0.2rem);
 }
 
-.open-result-node-pin {
+.result-node-pin {
   width: 0.72rem;
   height: 0.72rem;
   border: 2px solid var(--accent);
@@ -1909,30 +1909,30 @@ a {
   transform: translateY(-0.2rem);
 }
 
-.open-result-node-label,
-.open-result-node-weight {
+.result-node-label,
+.result-node-weight {
   font-family: "SFMono-Regular", Menlo, Consolas, monospace;
   font-size: 0.78rem;
   line-height: 1.4;
   white-space: nowrap;
 }
 
-.open-result-node-label {
+.result-node-label {
   margin-top: 0.7rem;
   color: var(--text);
 }
 
-.open-result-node-weight {
+.result-node-weight {
   color: var(--muted);
 }
 
-.open-result-rule-summary {
+.result-rule-summary {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
   border-top: 1px solid var(--line);
 }
 
-.open-result-rule-summary div {
+.result-rule-summary div {
   display: grid;
   gap: 0.7rem;
   min-height: 7.5rem;
@@ -1941,11 +1941,11 @@ a {
   align-content: space-between;
 }
 
-.open-result-rule-summary div:last-child {
+.result-rule-summary div:last-child {
   border-right: 0;
 }
 
-.open-result-rule-summary span {
+.result-rule-summary span {
   color: var(--muted);
   font-size: 0.78rem;
   font-weight: 600;
@@ -1953,7 +1953,7 @@ a {
   text-transform: uppercase;
 }
 
-.open-result-rule-summary strong {
+.result-rule-summary strong {
   color: var(--text);
   font-size: clamp(1.5rem, 3vw, 2.6rem);
   font-weight: 500;
@@ -1961,15 +1961,15 @@ a {
   letter-spacing: -0.05em;
 }
 
-.open-result-article {
+.result-article {
   width: min(100%, 74rem);
   max-width: 74rem;
   margin: 0 auto;
 }
 
-.open-result-article h2,
-.open-result-article h3,
-.open-result-article h4 {
+.result-article h2,
+.result-article h3,
+.result-article h4 {
   margin: 0;
   font-size: clamp(1.95rem, 4vw, 3.2rem);
   font-weight: 600;
@@ -1977,27 +1977,27 @@ a {
   letter-spacing: -0.05em;
 }
 
-.open-result-article h3 {
+.result-article h3 {
   font-size: clamp(1.5rem, 3vw, 2.35rem);
 }
 
-.open-result-article h4 {
+.result-article h4 {
   color: var(--text);
   font-size: clamp(1.05rem, 1.9vw, 1.35rem);
   letter-spacing: -0.03em;
 }
 
-.open-result-article h2:not(:first-child),
-.open-result-article h3:not(:first-child),
-.open-result-article h4:not(:first-child) {
+.result-article h2:not(:first-child),
+.result-article h3:not(:first-child),
+.result-article h4:not(:first-child) {
   margin-top: 3.2rem;
 }
 
-.open-result-article h4:not(:first-child) {
+.result-article h4:not(:first-child) {
   margin-top: 2.2rem;
 }
 
-.open-result-article p {
+.result-article p {
   max-width: 82ch;
   margin: 1.1rem 0 0;
   color: var(--muted-soft);
@@ -2007,22 +2007,22 @@ a {
   letter-spacing: -0.02em;
 }
 
-.open-result-article code {
+.result-article code {
   color: var(--text);
   font-family: "SFMono-Regular", Menlo, Consolas, monospace;
   font-size: 0.86em;
 }
 
-.open-result-article a {
+.result-article a {
   color: var(--accent);
   text-decoration: none;
 }
 
-.open-result-article a:hover {
+.result-article a:hover {
   text-decoration: underline;
 }
 
-.open-result-article pre {
+.result-article pre {
   overflow: auto;
   margin: 1.4rem 0 0;
   padding: 1.2rem;
@@ -2067,21 +2067,21 @@ a {
   display: block !important;
 }
 
-.open-result-whitepaper-shell {
+.result-whitepaper-shell {
   padding-top: clamp(2.7rem, 5vw, 4.4rem);
 }
 
-.open-result-whitepaper {
+.result-whitepaper {
   width: min(100%, 64rem);
   max-width: 64rem;
   min-width: 0;
 }
 
-.open-result-whitepaper * {
+.result-whitepaper * {
   min-width: 0;
 }
 
-.open-result-whitepaper h3 {
+.result-whitepaper h3 {
   margin-top: clamp(3rem, 6vw, 5rem);
   padding-top: 0.4rem;
   border-top: 1px solid var(--line);
@@ -2089,12 +2089,12 @@ a {
   letter-spacing: -0.04em;
 }
 
-.open-result-whitepaper h3:first-child {
+.result-whitepaper h3:first-child {
   margin-top: 0;
   border-top: 0;
 }
 
-.open-result-whitepaper p {
+.result-whitepaper p {
   max-width: 76ch;
   font-size: clamp(1.02rem, 1.45vw, 1.18rem);
   line-height: 1.62;
@@ -2102,29 +2102,29 @@ a {
   overflow-wrap: anywhere;
 }
 
-.open-result-whitepaper figcaption {
+.result-whitepaper figcaption {
   overflow-wrap: anywhere;
 }
 
-.open-result-whitepaper [id] {
+.result-whitepaper [id] {
   scroll-margin-top: 6rem;
 }
 
-.open-result-whitepaper .formula-block {
+.result-whitepaper .formula-block {
   max-width: 54rem;
   margin: 2rem auto 2.2rem;
 }
 
-.open-result-paper-table,
-.open-result-paper-asset,
-.open-result-paper-code {
+.result-paper-table,
+.result-paper-asset,
+.result-paper-code {
   width: min(100%, 48rem);
   margin: 2rem auto 2.6rem;
 }
 
-.open-result-paper-table figcaption,
-.open-result-paper-asset figcaption,
-.open-result-paper-code figcaption {
+.result-paper-table figcaption,
+.result-paper-asset figcaption,
+.result-paper-code figcaption {
   max-width: 38rem;
   margin: 0.72rem auto 0;
   color: var(--muted);
@@ -2135,51 +2135,51 @@ a {
   text-align: center;
 }
 
-.open-result-whitepaper .open-result-table {
+.result-whitepaper .result-table {
   border-top: 1px solid var(--line);
 }
 
-.open-result-whitepaper .open-result-table th,
-.open-result-whitepaper .open-result-table td {
+.result-whitepaper .result-table th,
+.result-whitepaper .result-table td {
   padding: 0.62rem 0.7rem 0.62rem 0;
 }
 
-.open-result-whitepaper .open-result-table th {
+.result-whitepaper .result-table th {
   font-family: Inter, Arial, sans-serif;
   font-size: 0.72rem;
 }
 
-.open-result-whitepaper .open-result-table td {
+.result-whitepaper .result-table td {
   color: var(--muted-soft);
   font-family: "SFMono-Regular", Menlo, Consolas, monospace;
   font-size: 0.88rem;
 }
 
-.open-result-contract-table {
+.result-contract-table {
   width: min(100%, 42rem);
 }
 
-.open-result-contract-table .open-result-table {
+.result-contract-table .result-table {
   margin: 0 auto;
 }
 
-.open-result-contract-table .open-result-table th,
-.open-result-contract-table .open-result-table td {
+.result-contract-table .result-table th,
+.result-contract-table .result-table td {
   padding-right: 1.2rem;
   text-align: center;
 }
 
-.open-result-contract-table .open-result-table th:first-child,
-.open-result-contract-table .open-result-table td:first-child {
+.result-contract-table .result-table th:first-child,
+.result-contract-table .result-table td:first-child {
   width: 3.5rem;
 }
 
-.open-result-contract-table .open-result-table th:last-child,
-.open-result-contract-table .open-result-table td:last-child {
+.result-contract-table .result-table th:last-child,
+.result-contract-table .result-table td:last-child {
   padding-right: 0;
 }
 
-.open-result-contract-table .open-result-table td {
+.result-contract-table .result-table td {
   font-family: Georgia, "Times New Roman", serif;
   font-size: 1rem;
 }
@@ -2192,42 +2192,42 @@ a {
   letter-spacing: 0;
 }
 
-.rcpsp-whitepaper .open-result-paper-table {
+.rcpsp-whitepaper .result-paper-table {
   width: min(100%, 54rem);
 }
 
-.rcpsp-whitepaper .open-result-contract-table {
+.rcpsp-whitepaper .result-contract-table {
   width: min(100%, 50rem);
 }
 
-.rcpsp-whitepaper .open-result-table td code {
+.rcpsp-whitepaper .result-table td code {
   color: var(--text);
   font-size: 0.92em;
 }
 
-.rcpsp-whitepaper .open-result-paper-asset {
+.rcpsp-whitepaper .result-paper-asset {
   width: min(100%, 56rem);
 }
 
-.open-result-rcpsp-page .open-result-paper-asset img {
+.result-rcpsp-page .result-paper-asset img {
   background: var(--bg);
 }
 
-.open-result-whitepaper .open-result-paper-asset img[src$=".svg"] {
+.result-whitepaper .result-paper-asset img[src$=".svg"] {
   filter: invert(1) hue-rotate(180deg);
 }
 
 @media (prefers-color-scheme: dark) {
-  .open-result-whitepaper .open-result-paper-asset img[src$=".svg"] {
+  .result-whitepaper .result-paper-asset img[src$=".svg"] {
     filter: none;
   }
 }
 
-.rcpsp-whitepaper .open-result-paper-code {
+.rcpsp-whitepaper .result-paper-code {
   width: min(100%, 56rem);
 }
 
-.open-result-whitepaper .open-result-code-figure {
+.result-whitepaper .result-code-figure {
   --code-bg: #f7f8fb;
   --code-gutter: #eef2f6;
   --code-border: rgba(10, 10, 10, 0.18);
@@ -2241,12 +2241,12 @@ a {
   width: min(100%, 56rem);
 }
 
-.rcpsp-whitepaper .open-result-paper-code pre {
+.rcpsp-whitepaper .result-paper-code pre {
   max-height: 36rem;
   scrollbar-width: thin;
 }
 
-.open-result-whitepaper .open-result-code-figure pre {
+.result-whitepaper .result-code-figure pre {
   max-height: none;
   padding: 0;
   border: 1px solid var(--code-border);
@@ -2255,12 +2255,12 @@ a {
     var(--code-bg);
 }
 
-.open-result-code-figure code {
+.result-code-figure code {
   display: block;
   padding: 1rem 0;
 }
 
-.open-result-code-figure .code-line {
+.result-code-figure .code-line {
   display: grid;
   grid-template-columns: 2.7rem minmax(0, 1fr);
   gap: 0.85rem;
@@ -2271,40 +2271,40 @@ a {
   white-space: pre;
 }
 
-.open-result-code-figure .line-no {
+.result-code-figure .line-no {
   color: var(--code-line-no);
   text-align: right;
   user-select: none;
 }
 
-.open-result-code-figure .line-src {
+.result-code-figure .line-src {
   min-width: 0;
 }
 
-.open-result-code-figure .py-keyword {
+.result-code-figure .py-keyword {
   color: var(--code-keyword);
   font-weight: 700;
 }
 
-.open-result-code-figure .py-builtin {
+.result-code-figure .py-builtin {
   color: var(--code-builtin);
 }
 
-.open-result-code-figure .py-string {
+.result-code-figure .py-string {
   color: var(--code-string);
 }
 
-.open-result-code-figure .py-comment {
+.result-code-figure .py-comment {
   color: var(--code-comment);
   font-style: italic;
 }
 
-.open-result-code-figure .py-constant {
+.result-code-figure .py-constant {
   color: var(--code-constant);
 }
 
 @media (prefers-color-scheme: dark) {
-  .open-result-whitepaper .open-result-code-figure {
+  .result-whitepaper .result-code-figure {
     --code-bg: #050608;
     --code-gutter: color-mix(in srgb, var(--panel) 72%, transparent);
     --code-border: var(--line);
@@ -2319,14 +2319,14 @@ a {
 }
 
 @media (max-width: 720px) {
-  .open-result-code-figure .code-line {
+  .result-code-figure .code-line {
     grid-template-columns: 2.35rem max-content;
     min-width: max-content;
     padding-right: 1.2rem;
   }
 }
 
-.open-result-paper-asset img {
+.result-paper-asset img {
   display: block;
   width: 100%;
   height: auto;
@@ -2334,7 +2334,7 @@ a {
   border-bottom: 1px solid var(--line);
 }
 
-.open-result-paper-code pre {
+.result-paper-code pre {
   overflow: auto;
   margin: 0;
   padding: clamp(1rem, 2vw, 1.35rem);
@@ -2346,131 +2346,131 @@ a {
   line-height: 1.65;
 }
 
-.open-result-accepted-rule-svg {
+.result-accepted-rule-svg {
   margin-top: 0.2rem;
 }
 
-.open-result-rule-paper-axis {
+.result-rule-paper-axis {
   fill: none;
   stroke: color-mix(in srgb, var(--text) 58%, transparent);
   stroke-width: 1;
 }
 
-.open-result-reference-axis {
+.result-reference-axis {
   fill: none;
   stroke: color-mix(in srgb, var(--text) 26%, transparent);
   stroke-width: 1;
 }
 
-.open-result-reference-node line {
+.result-reference-node line {
   stroke: color-mix(in srgb, var(--text) 34%, transparent);
   stroke-width: 1;
 }
 
-.open-result-reference-node circle {
+.result-reference-node circle {
   fill: var(--bg);
   stroke: color-mix(in srgb, var(--text) 42%, transparent);
   stroke-width: 1.4;
 }
 
-.open-result-baseline-node line {
+.result-baseline-node line {
   stroke: color-mix(in srgb, var(--text) 52%, transparent);
   stroke-width: 1.1;
 }
 
-.open-result-baseline-node circle {
+.result-baseline-node circle {
   fill: var(--bg);
   stroke: color-mix(in srgb, var(--text) 58%, transparent);
   stroke-width: 1.7;
 }
 
-.open-result-figure-legend rect {
+.result-figure-legend rect {
   fill: var(--bg);
   stroke: color-mix(in srgb, var(--text) 22%, transparent);
   stroke-width: 0.8;
 }
 
-.open-result-figure-legend text {
+.result-figure-legend text {
   fill: var(--muted);
   font-family: Georgia, "Times New Roman", serif;
   font-size: 10px;
 }
 
-.open-result-legend-accepted-line {
+.result-legend-accepted-line {
   stroke: color-mix(in srgb, var(--text) 70%, transparent);
   stroke-width: 1.4;
 }
 
-.open-result-legend-accepted-dot {
+.result-legend-accepted-dot {
   fill: var(--bg);
   stroke: var(--accent);
   stroke-width: 2;
 }
 
-.open-result-legend-reference-line {
+.result-legend-reference-line {
   stroke: color-mix(in srgb, var(--text) 38%, transparent);
   stroke-width: 1;
 }
 
-.open-result-legend-reference-dot {
+.result-legend-reference-dot {
   fill: var(--bg);
   stroke: color-mix(in srgb, var(--text) 44%, transparent);
   stroke-width: 1.4;
 }
 
-.open-result-legend-baseline-line {
+.result-legend-baseline-line {
   stroke: color-mix(in srgb, var(--text) 52%, transparent);
   stroke-width: 1.1;
 }
 
-.open-result-legend-baseline-dot {
+.result-legend-baseline-dot {
   fill: var(--bg);
   stroke: color-mix(in srgb, var(--text) 58%, transparent);
   stroke-width: 1.7;
 }
 
-.open-result-accepted-node line {
+.result-accepted-node line {
   stroke: color-mix(in srgb, var(--text) 70%, transparent);
   stroke-width: 1.4;
 }
 
-.open-result-accepted-node circle {
+.result-accepted-node circle {
   fill: var(--bg);
   stroke: var(--accent);
   stroke-width: 2;
 }
 
-.open-result-accepted-node text {
+.result-accepted-node text {
   fill: var(--muted);
   font-family: "Times New Roman", Georgia, serif;
   font-size: 11px;
   text-anchor: middle;
 }
 
-.open-result-assets {
+.result-assets {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 0;
   padding: 0 var(--content-gutter) clamp(2.4rem, 6vw, 5rem);
 }
 
-.open-result-figure {
+.result-figure {
   margin: 0;
   border: 1px solid var(--line);
   border-right: 0;
 }
 
-.open-result-figure:last-child {
+.result-figure:last-child {
   border-right: 1px solid var(--line);
 }
 
-.open-result-figure img {
+.result-figure img {
   display: block;
   width: 100%;
   height: auto;
 }
 
-.open-result-figure figcaption {
+.result-figure figcaption {
   min-height: 4.5rem;
   padding: 1rem clamp(1rem, 2vw, 1.4rem);
   border-top: 1px solid var(--line);
@@ -2481,23 +2481,23 @@ a {
   letter-spacing: -0.01em;
 }
 
-.open-result-evidence {
+.result-evidence {
   display: grid;
   gap: clamp(1.8rem, 3vw, 2.6rem);
   padding: clamp(2.4rem, 6vw, 5rem) var(--content-gutter);
   border-top: 1px solid var(--line);
 }
 
-.open-result-evidence-heading {
+.result-evidence-heading {
   max-width: 78rem;
 }
 
-.open-result-evidence-heading .eyebrow {
+.result-evidence-heading .eyebrow {
   margin: 0 0 1rem;
 }
 
-.open-result-evidence-heading h2,
-.open-result-code-heading h2 {
+.result-evidence-heading h2,
+.result-code-heading h2 {
   max-width: 16ch;
   margin: 0;
   font-size: clamp(2.4rem, 5.2vw, 5rem);
@@ -2506,7 +2506,7 @@ a {
   letter-spacing: -0.06em;
 }
 
-.open-result-evidence-heading p:not(.eyebrow) {
+.result-evidence-heading p:not(.eyebrow) {
   max-width: 82ch;
   margin: 1.2rem 0 0;
   color: var(--muted-soft);
@@ -2516,16 +2516,16 @@ a {
   letter-spacing: -0.02em;
 }
 
-.open-result-metric-grid,
-.open-result-evolution-summary {
+.result-metric-grid,
+.result-evolution-summary {
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));
   border-top: 1px solid var(--line);
   border-bottom: 1px solid var(--line);
 }
 
-.open-result-metric-card,
-.open-result-evolution-summary div {
+.result-metric-card,
+.result-evolution-summary div {
   display: grid;
   gap: 0.75rem;
   min-height: 8.5rem;
@@ -2534,21 +2534,21 @@ a {
   align-content: space-between;
 }
 
-.open-result-metric-card:last-child,
-.open-result-evolution-summary div:last-child {
+.result-metric-card:last-child,
+.result-evolution-summary div:last-child {
   border-right: 0;
 }
 
-.open-result-metric-card span,
-.open-result-evolution-summary span {
+.result-metric-card span,
+.result-evolution-summary span {
   color: var(--muted);
   font-size: 0.8rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
 
-.open-result-metric-card strong,
-.open-result-evolution-summary strong {
+.result-metric-card strong,
+.result-evolution-summary strong {
   color: var(--text);
   font-size: clamp(1.6rem, 3.2vw, 2.8rem);
   font-weight: 500;
@@ -2556,27 +2556,27 @@ a {
   letter-spacing: -0.05em;
 }
 
-.open-result-data-grid {
+.result-data-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   border-top: 1px solid var(--line);
   border-bottom: 1px solid var(--line);
 }
 
-.open-result-data-grid-1 {
+.result-data-grid-1 {
   grid-template-columns: minmax(0, 1fr);
 }
 
-.open-result-data-grid > div {
+.result-data-grid > div {
   padding: clamp(1.1rem, 2vw, 1.6rem);
   border-right: 1px solid var(--line);
 }
 
-.open-result-data-grid > div:last-child {
+.result-data-grid > div:last-child {
   border-right: 0;
 }
 
-.open-result-data-grid h3 {
+.result-data-grid h3 {
   margin: 0 0 1.4rem;
   font-size: clamp(1.55rem, 3vw, 2.4rem);
   font-weight: 600;
@@ -2584,23 +2584,23 @@ a {
   letter-spacing: -0.05em;
 }
 
-.open-result-table-wrap {
+.result-table-wrap {
   overflow-x: auto;
 }
 
-.open-result-table {
+.result-table {
   width: 100%;
   border-collapse: collapse;
 }
 
-.open-result-table th,
-.open-result-table td {
+.result-table th,
+.result-table td {
   padding: 0.78rem 0;
   border-bottom: 1px solid var(--line);
   text-align: left;
 }
 
-.open-result-table th {
+.result-table th {
   color: var(--muted);
   font-size: 0.78rem;
   font-weight: 500;
@@ -2608,37 +2608,37 @@ a {
   text-transform: uppercase;
 }
 
-.open-result-table td {
+.result-table td {
   color: var(--muted-soft);
   font-family: "SFMono-Regular", Menlo, Consolas, monospace;
   font-size: 0.95rem;
 }
 
-.open-result-table a {
+.result-table a {
   color: var(--accent);
   text-decoration: none;
 }
 
-.open-result-table a:hover {
+.result-table a:hover {
   text-decoration: underline;
 }
 
-.open-result-code {
+.result-code {
   display: grid;
   grid-template-columns: minmax(14rem, 0.26fr) minmax(0, 1fr);
   gap: clamp(2rem, 6vw, 6rem);
   padding: 0 var(--content-gutter) clamp(3rem, 7vw, 6rem);
 }
 
-.open-result-code-heading .eyebrow {
+.result-code-heading .eyebrow {
   margin: 0 0 1rem;
 }
 
-.open-result-code-heading h2 {
+.result-code-heading h2 {
   font-size: clamp(2rem, 4vw, 3.2rem);
 }
 
-.open-result-code pre {
+.result-code pre {
   overflow: auto;
   margin: 0;
   padding: clamp(1rem, 2vw, 1.4rem);
@@ -2895,41 +2895,41 @@ a {
     grid-template-columns: 1fr;
   }
 
-  .open-result-card {
+  .result-card {
     min-height: 25rem;
     border-right: 0;
     border-bottom: 1px solid var(--line);
   }
 
-  .open-result-card:last-child {
+  .result-card:last-child {
     border-bottom: 0;
   }
 
-  .open-result-card h2 {
+  .result-card h2 {
     max-width: 11ch;
   }
 
-  .open-result-card--quadrature p {
+  .result-card--quadrature p {
     max-width: 31ch;
   }
 
-  .open-result-card--rcpsp h2 {
+  .result-card--rcpsp h2 {
     max-width: 12ch;
     font-size: clamp(2rem, 12vw, 3rem);
   }
 
-  .open-result-card--rcpsp p {
+  .result-card--rcpsp p {
     max-width: 31ch;
   }
 
-  .open-result-card-visual {
+  .result-card-visual {
     right: -7rem;
     bottom: 5.5rem;
     width: 72%;
     opacity: 0.24;
   }
 
-  .open-result-card--rcpsp .open-result-card-visual {
+  .result-card--rcpsp .result-card-visual {
     display: block;
     right: -7rem;
     bottom: 5.5rem;
@@ -2937,132 +2937,132 @@ a {
     opacity: 0.24;
   }
 
-  .open-result-measure {
+  .result-measure {
     grid-template-columns: 1fr;
   }
 
-  .open-result-snapshot,
-  .open-result-snapshot-cards,
-  .open-result-primer {
+  .result-snapshot,
+  .result-snapshot-cards,
+  .result-primer {
     grid-template-columns: 1fr;
   }
 
-  .open-result-snapshot-primary {
+  .result-snapshot-primary {
     min-height: 13rem;
     border-right: 0;
     border-bottom: 1px solid var(--line);
   }
 
-  .open-result-snapshot-cards div {
+  .result-snapshot-cards div {
     min-height: 6.8rem;
     border-right: 0;
   }
 
-  .open-result-snapshot-cards div:nth-last-child(-n + 2) {
+  .result-snapshot-cards div:nth-last-child(-n + 2) {
     border-bottom: 1px solid var(--line);
   }
 
-  .open-result-snapshot-cards div:last-child {
+  .result-snapshot-cards div:last-child {
     border-bottom: 0;
   }
 
-  .open-result-primer-copy h2 {
+  .result-primer-copy h2 {
     max-width: 12ch;
   }
 
-  .open-result-primer-panel {
+  .result-primer-panel {
     min-height: 21rem;
   }
 
-  .open-result-primer-card {
+  .result-primer-card {
     grid-template-columns: 1fr;
   }
 
-  .open-result-primer-card figcaption {
+  .result-primer-card figcaption {
     border-right: 0;
     border-bottom: 0;
   }
 
-  .open-result-primer-card figcaption strong {
+  .result-primer-card figcaption strong {
     max-width: 18ch;
   }
 
-  .open-result-rule-visual,
-  .open-result-rule-summary {
+  .result-rule-visual,
+  .result-rule-summary {
     grid-template-columns: 1fr;
   }
 
-  .open-result-rule-copy h2 {
+  .result-rule-copy h2 {
     max-width: 12ch;
   }
 
-  .open-result-rule-panel {
+  .result-rule-panel {
     min-height: 28rem;
   }
 
-  .open-result-node-label,
-  .open-result-node-weight {
+  .result-node-label,
+  .result-node-weight {
     font-size: 0.68rem;
   }
 
-  .open-result-rule-summary div {
+  .result-rule-summary div {
     border-right: 0;
     border-bottom: 1px solid var(--line);
   }
 
-  .open-result-rule-summary div:last-child {
+  .result-rule-summary div:last-child {
     border-bottom: 0;
   }
 
-  .open-result-assets {
+  .result-assets {
     grid-template-columns: 1fr;
   }
 
-  .open-result-figure {
+  .result-figure {
     border-right: 1px solid var(--line);
     border-bottom: 0;
   }
 
-  .open-result-figure:last-child {
+  .result-figure:last-child {
     border-bottom: 1px solid var(--line);
   }
 
-  .open-result-metric-grid,
-  .open-result-evolution-summary,
-  .open-result-data-grid,
-  .open-result-code {
+  .result-metric-grid,
+  .result-evolution-summary,
+  .result-data-grid,
+  .result-code {
     grid-template-columns: 1fr;
   }
 
-  .open-result-metric-card,
-  .open-result-evolution-summary div,
-  .open-result-data-grid > div {
+  .result-metric-card,
+  .result-evolution-summary div,
+  .result-data-grid > div {
     border-right: 0;
     border-bottom: 1px solid var(--line);
   }
 
-  .open-result-metric-card:last-child,
-  .open-result-evolution-summary div:last-child,
-  .open-result-data-grid > div:last-child {
+  .result-metric-card:last-child,
+  .result-evolution-summary div:last-child,
+  .result-data-grid > div:last-child {
     border-bottom: 0;
   }
 
-  .open-result-code {
+  .result-code {
     gap: 2rem;
   }
 
-  .open-result-whitepaper {
+  .result-whitepaper {
     width: 100%;
     max-width: 100%;
     min-width: 0;
   }
 
-  .open-result-whitepaper p,
-  .open-result-whitepaper figcaption {
+  .result-whitepaper p,
+  .result-whitepaper figcaption {
     overflow-wrap: anywhere;
   }
 
-  .open-result-whitepaper .formula-block {
+  .result-whitepaper .formula-block {
     grid-template-columns: minmax(0, 1fr);
     gap: 0.35rem;
     max-width: 100%;
@@ -3071,31 +3071,31 @@ a {
     overflow-x: hidden;
   }
 
-  .open-result-whitepaper .formula-math {
+  .result-whitepaper .formula-math {
     overflow-x: auto;
     padding-bottom: 0.25rem;
     scrollbar-width: thin;
   }
 
-  .open-result-whitepaper .equation-number {
+  .result-whitepaper .equation-number {
     justify-self: end;
   }
 
-  .open-result-paper-table,
-  .open-result-paper-asset,
-  .open-result-paper-code,
-  .open-result-primer-card {
+  .result-paper-table,
+  .result-paper-asset,
+  .result-paper-code,
+  .result-primer-card {
     width: 100%;
     max-width: 100%;
     overflow: hidden;
   }
 
-  .open-result-table-wrap {
+  .result-table-wrap {
     overflow-x: auto;
     scrollbar-width: thin;
   }
 
-  .open-result-primer-svg {
+  .result-primer-svg {
     max-width: 100%;
     width: 100%;
   }
@@ -3157,7 +3157,7 @@ a {
   }
 
   .page-hero .intro,
-  .open-result-rule-copy p:not(.eyebrow) {
+  .result-rule-copy p:not(.eyebrow) {
     max-width: 100%;
   }
 }

--- a/tools/sync-results.mjs
+++ b/tools/sync-results.mjs
@@ -246,8 +246,8 @@ function resultCardMeasureItems(result) {
 
 function resultCardVisual(result) {
   if (result.website?.card_visual === "rcpsp") {
-    return `<svg class="open-result-card-visual open-result-card-visual--rcpsp" viewBox="0 0 560 360" aria-hidden="true" focusable="false">
-                <g class="open-result-card-rcpsp">
+    return `<svg class="result-card-visual result-card-visual--rcpsp" viewBox="0 0 560 360" aria-hidden="true" focusable="false">
+                <g class="result-card-rcpsp">
                   <g class="schedule">
                     <path class="lane" d="M52 92 H508 M52 128 H508 M52 164 H508 M52 200 H508 M52 236 H508" />
                     <path class="axis" d="M52 258 H508" />
@@ -305,7 +305,7 @@ function resultCardVisual(result) {
 
   if (result.website?.card_visual !== "quadrature") return "";
 
-  return `<svg class="open-result-card-visual" viewBox="0 0 560 360" aria-hidden="true" focusable="false">
+  return `<svg class="result-card-visual" viewBox="0 0 560 360" aria-hidden="true" focusable="false">
                 <defs>
                   <clipPath id="quadrature-card-area">
                     <path d="M44 286 L44 230 C95 166 154 109 226 82 C310 50 409 72 516 148 L516 286 Z" />
@@ -314,7 +314,7 @@ function resultCardVisual(result) {
                     <line x1="0" y1="0" x2="0" y2="18" />
                   </pattern>
                 </defs>
-                <g class="open-result-card-chart">
+                <g class="result-card-chart">
                   <line x1="44" y1="286" x2="516" y2="286" />
                   <line x1="44" y1="286" x2="44" y2="48" />
                   <line x1="44" y1="92" x2="516" y2="92" class="grid" />
@@ -339,17 +339,17 @@ function resultCardVisual(result) {
 
 function resultCard(result) {
   const measures = resultCardMeasureItems(result);
-  const visualClass = result.website?.card_visual ? ` open-result-card--${escapeHtml(result.website.card_visual)}` : "";
+  const visualClass = result.website?.card_visual ? ` result-card--${escapeHtml(result.website.card_visual)}` : "";
   const visual = resultCardVisual(result);
   const visualMarkup = visual ? `              ${visual}\n` : "";
-  return `<article class="open-result-card${visualClass}">
-            <a class="open-result-link" href="./${result.slug}/" aria-label="Read ${escapeHtml(result.title)}">
-${visualMarkup}              <div class="open-result-meta">
+  return `<article class="result-card${visualClass}">
+            <a class="result-link" href="./${result.slug}/" aria-label="Read ${escapeHtml(result.title)}">
+${visualMarkup}              <div class="result-meta">
                 <p class="eyebrow">${escapeHtml(result.website.card_label)}</p>
               </div>
               <h2>${escapeHtml(result.title)}</h2>
               <p>${escapeHtml(result.website.card_summary || result.summary)}</p>
-              <div class="open-result-measure">
+              <div class="result-measure">
                 ${measures.map(([label, value]) => `<span>${escapeHtml(label)}</span>
                 <strong>${escapeHtml(value)}</strong>`).join("\n                ")}
               </div>
@@ -470,13 +470,13 @@ function resultSnapshot(full, evolution) {
     cards.push(["Acceptance objective", formatNumber(full.metrics.best)]);
   }
 
-  return `<section class="open-result-snapshot" aria-label="Result summary">
-            <div class="open-result-snapshot-primary">
+  return `<section class="result-snapshot" aria-label="Result summary">
+            <div class="result-snapshot-primary">
               <span>${escapeHtml(primary.label)}</span>
               <strong>${primary.value}</strong>
               <p>${escapeHtml(primary.note)}</p>
             </div>
-            <div class="open-result-snapshot-cards">
+            <div class="result-snapshot-cards">
 ${cards
   .slice(0, 4)
   .map(
@@ -505,14 +505,14 @@ function quadratureProblemVisuals() {
     return 0.86 * envelope * (0.86 + 0.14 * x) + 0.05 * x * (1 - x);
   };
   const plotClipRect = `<rect x="${plot.left}" y="${plot.top - 2}" width="${plot.right - plot.left}" height="${plot.base - plot.top + 2}" />`;
-  const axes = `<path class="open-result-primer-grid" d="M${plot.left} ${plot.top} V${plot.base} H${plot.right}" />
-                <path class="open-result-objective-grid" d="M${plot.left} ${mapY(1).toFixed(1)} H${plot.right}" />
-                <text class="open-result-axis-tick open-result-y-tick" x="${plot.left - 16}" y="${mapY(1) + 4}">1</text>
-                <path class="open-result-axis-notch" d="M${plot.left - 6} ${mapY(1)} H${plot.left}" />
-                <text class="open-result-axis-tick" x="${plot.left}" y="${plot.base + 22}">0</text>
-                <text class="open-result-axis-tick" x="${plot.right}" y="${plot.base + 22}">1</text>
-                <text class="open-result-axis-label open-result-x-axis-title" x="${(plot.left + plot.right) / 2}" y="${plot.base + 48}">x</text>
-                <text class="open-result-axis-label open-result-objective-y-title" x="34" y="${plot.top + (plot.base - plot.top) / 2}" transform="rotate(-90 34 ${plot.top + (plot.base - plot.top) / 2})">g(x)</text>`;
+  const axes = `<path class="result-primer-grid" d="M${plot.left} ${plot.top} V${plot.base} H${plot.right}" />
+                <path class="result-objective-grid" d="M${plot.left} ${mapY(1).toFixed(1)} H${plot.right}" />
+                <text class="result-axis-tick result-y-tick" x="${plot.left - 16}" y="${mapY(1) + 4}">1</text>
+                <path class="result-axis-notch" d="M${plot.left - 6} ${mapY(1)} H${plot.left}" />
+                <text class="result-axis-tick" x="${plot.left}" y="${plot.base + 22}">0</text>
+                <text class="result-axis-tick" x="${plot.right}" y="${plot.base + 22}">1</text>
+                <text class="result-axis-label result-x-axis-title" x="${(plot.left + plot.right) / 2}" y="${plot.base + 48}">x</text>
+                <text class="result-axis-label result-objective-y-title" x="34" y="${plot.top + (plot.base - plot.top) / 2}" transform="rotate(-90 34 ${plot.top + (plot.base - plot.top) / 2})">g(x)</text>`;
   const samples = Array.from({ length: 90 }, (_, index) => {
     const x = index / 89;
     const y = conceptFunction(x);
@@ -536,7 +536,7 @@ function quadratureProblemVisuals() {
     const right = mapX(x1);
     const x = mapX(node);
     const y = mapY(value);
-    return `<g class="open-result-concept-sample ${index === 2 ? "is-accepted" : ""}">
+    return `<g class="result-concept-sample ${index === 2 ? "is-accepted" : ""}">
               <rect x="${left.toFixed(1)}" y="${y.toFixed(1)}" width="${(right - left).toFixed(1)}" height="${(plot.base - y).toFixed(1)}" />
               <line x1="${x.toFixed(1)}" y1="${plot.base}" x2="${x.toFixed(1)}" y2="${y.toFixed(1)}" />
               <circle cx="${x.toFixed(1)}" cy="${y.toFixed(1)}" r="4.2" />
@@ -552,7 +552,7 @@ function quadratureProblemVisuals() {
       return [mapX(x), mapY(conceptFunction(x))];
     });
     const meanCurveY = regionSamples.reduce((sum, [, y]) => sum + y, 0) / regionSamples.length;
-    const residualClass = meanCurveY < estimateY ? "open-result-residual-positive" : "open-result-residual-negative";
+    const residualClass = meanCurveY < estimateY ? "result-residual-positive" : "result-residual-negative";
     const curveEdge = regionSamples
       .slice()
       .reverse()
@@ -562,15 +562,15 @@ function quadratureProblemVisuals() {
     return { pathData, residualClass };
   });
   const residualRegions = residualRegionPaths
-    .map(({ pathData, residualClass }) => `<path class="open-result-residual-region ${residualClass}" d="${pathData}" />`)
+    .map(({ pathData, residualClass }) => `<path class="result-residual-region ${residualClass}" d="${pathData}" />`)
     .join("\n");
   const residualHatches = residualRegionPaths
-    .map(({ pathData }) => `<path class="open-result-residual-hatch" d="${pathData}" />`)
+    .map(({ pathData }) => `<path class="result-residual-hatch" d="${pathData}" />`)
     .join("\n");
 
   return {
-    "exact-integral": `<figure class="open-result-primer-card open-result-paper-figure" id="fig-1">
-              <svg class="open-result-primer-svg open-result-paper-chart-svg" viewBox="0 0 560 306" role="img" aria-label="Conceptual exact integral for an arbitrary function g on the unit interval.">
+    "exact-integral": `<figure class="result-primer-card result-paper-figure" id="fig-1">
+              <svg class="result-primer-svg result-paper-chart-svg" viewBox="0 0 560 306" role="img" aria-label="Conceptual exact integral for an arbitrary function g on the unit interval.">
                 <defs>
                   <clipPath id="conceptExactPlotClip">
                     ${plotClipRect}
@@ -582,18 +582,18 @@ function quadratureProblemVisuals() {
                     <line x1="0" y1="0" x2="0" y2="12" />
                   </pattern>
                 </defs>
-                <text class="open-result-axis-label open-result-figure-title" x="${plot.left}" y="34">Conceptual integral of an arbitrary g(x)</text>
+                <text class="result-axis-label result-figure-title" x="${plot.left}" y="34">Conceptual integral of an arbitrary g(x)</text>
                 ${axes}
                 <g clip-path="url(#conceptExactPlotClip)">
-                  <path class="open-result-primer-area exact-integral-area" d="${areaPath}" />
-                  <rect class="open-result-integral-hatch" x="${plot.left}" y="${plot.top}" width="${plot.right - plot.left}" height="${plot.base - plot.top}" clip-path="url(#conceptExactIntegralClip)" />
-                  <path class="open-result-primer-curve" d="${curvePath}" />
+                  <path class="result-primer-area exact-integral-area" d="${areaPath}" />
+                  <rect class="result-integral-hatch" x="${plot.left}" y="${plot.top}" width="${plot.right - plot.left}" height="${plot.base - plot.top}" clip-path="url(#conceptExactIntegralClip)" />
+                  <path class="result-primer-curve" d="${curvePath}" />
                 </g>
               </svg>
               <figcaption>Figure 1. Conceptual setup for the exact integral. The shaded surface denotes \\(I[g]\\) for an arbitrary function \\(g\\), separate from the public integrand suite used by the evaluation contract.</figcaption>
             </figure>`,
-    "quadrature-rule": `<figure class="open-result-primer-card open-result-paper-figure" id="fig-2">
-              <svg class="open-result-primer-svg open-result-paper-chart-svg" viewBox="0 0 560 306" role="img" aria-label="Conceptual quadrature rule showing weighted point evaluations of an arbitrary function.">
+    "quadrature-rule": `<figure class="result-primer-card result-paper-figure" id="fig-2">
+              <svg class="result-primer-svg result-paper-chart-svg" viewBox="0 0 560 306" role="img" aria-label="Conceptual quadrature rule showing weighted point evaluations of an arbitrary function.">
                 <defs>
                   <clipPath id="conceptQuadraturePlotClip">
                     ${plotClipRect}
@@ -602,22 +602,22 @@ function quadratureProblemVisuals() {
                     <line x1="0" y1="0" x2="0" y2="12" />
                   </pattern>
                 </defs>
-                <text class="open-result-axis-label open-result-figure-title" x="${plot.left}" y="34">Weighted point evaluations</text>
+                <text class="result-axis-label result-figure-title" x="${plot.left}" y="34">Weighted point evaluations</text>
                 ${axes}
                 <g clip-path="url(#conceptQuadraturePlotClip)">
-                  <g class="open-result-concept-samples">
+                  <g class="result-concept-samples">
 ${quadratureCells.join("\n")}
                   </g>
-                  <g class="open-result-concept-samples open-result-concept-sample-hatches">
+                  <g class="result-concept-samples result-concept-sample-hatches">
 ${quadratureCells.join("\n")}
                   </g>
-                  <path class="open-result-primer-curve muted-curve dashed-curve" d="${curvePath}" />
+                  <path class="result-primer-curve muted-curve dashed-curve" d="${curvePath}" />
                 </g>
               </svg>
               <figcaption>Figure 2. Quadrature replaces the continuous integral with weighted point evaluations. The blue cells are the estimate \\(Q_r[g]\\): each cell width represents \\(w_i\\), each height is \\(g(x_i)\\), and each area is one contribution \\(w_i g(x_i)\\).</figcaption>
             </figure>`,
-    "residual-error": `<figure class="open-result-primer-card open-result-paper-figure" id="fig-3">
-              <svg class="open-result-primer-svg open-result-paper-chart-svg" viewBox="0 0 560 306" role="img" aria-label="Conceptual residual between the exact integral and weighted quadrature estimate.">
+    "residual-error": `<figure class="result-primer-card result-paper-figure" id="fig-3">
+              <svg class="result-primer-svg result-paper-chart-svg" viewBox="0 0 560 306" role="img" aria-label="Conceptual residual between the exact integral and weighted quadrature estimate.">
                 <defs>
                   <clipPath id="conceptResidualPlotClip">
                     ${plotClipRect}
@@ -626,19 +626,19 @@ ${quadratureCells.join("\n")}
                     <line x1="0" y1="0" x2="0" y2="12" />
                   </pattern>
                 </defs>
-                <text class="open-result-axis-label open-result-figure-title" x="${plot.left}" y="34">Residual between I[g] and Q<tspan baseline-shift="sub" font-size="9">r</tspan><tspan dx="4">[g]</tspan></text>
+                <text class="result-axis-label result-figure-title" x="${plot.left}" y="34">Residual between I[g] and Q<tspan baseline-shift="sub" font-size="9">r</tspan><tspan dx="4">[g]</tspan></text>
                 ${axes}
                 <g clip-path="url(#conceptResidualPlotClip)">
-                  <g class="open-result-concept-samples open-result-concept-samples-muted">
+                  <g class="result-concept-samples result-concept-samples-muted">
 ${quadratureCells.join("\n")}
                   </g>
-                  <g class="open-result-residual-regions">
+                  <g class="result-residual-regions">
 ${residualRegions}
                   </g>
-                  <g class="open-result-residual-hatches">
+                  <g class="result-residual-hatches">
 ${residualHatches}
                   </g>
-                  <path class="open-result-primer-curve" d="${curvePath}" />
+                  <path class="result-primer-curve" d="${curvePath}" />
                 </g>
               </svg>
               <figcaption>Figure 3. Conceptual residual diagnostic. Local over- and under-estimation can coexist; the reported scalar residual is the absolute net difference between the quadrature estimate and the exact integral.</figcaption>
@@ -648,8 +648,8 @@ ${residualHatches}
 
 function metricTable(rows) {
   if (!rows.length) return "";
-  return `<div class="open-result-table-wrap">
-          <table class="open-result-table">
+  return `<div class="result-table-wrap">
+          <table class="result-table">
             <tbody>
 ${rows
   .map(
@@ -665,12 +665,12 @@ ${rows
 }
 
 function paperTable({ caption, headers, rows, className = "" }) {
-  const figureClass = ["open-result-paper-table", className].filter(Boolean).join(" ");
+  const figureClass = ["result-paper-table", className].filter(Boolean).join(" ");
   const captionId = caption?.match(/^Table\s+(\d+)/)?.[1];
   const idAttribute = captionId ? ` id="table-${captionId}"` : "";
   return `<figure class="${figureClass}"${idAttribute}>
-          <div class="open-result-table-wrap">
-            <table class="open-result-table">
+          <div class="result-table-wrap">
+            <table class="result-table">
               <thead>
                 <tr>
 ${headers.map((header) => `                  <th>${escapeHtml(header)}</th>`).join("\n")}
@@ -751,7 +751,7 @@ function ruleDistributionFigure({ rule, figureNumber, title, subtitle, markerCla
     width: 430,
   };
   const subtitleMarkup = subtitle
-    ? `<text class="open-result-axis-label open-result-panel-subtitle" x="${panel.left}" y="54">${subtitle}</text>`
+    ? `<text class="result-axis-label result-panel-subtitle" x="${panel.left}" y="54">${subtitle}</text>`
     : "";
   const mapX = (node) => panel.left + node * panel.width;
   const mapY = (top, weight) => top + panel.height - (weight / yMax) * panel.height;
@@ -761,8 +761,8 @@ function ruleDistributionFigure({ rule, figureNumber, title, subtitle, markerCla
       const y = mapY(top, tick);
       const label = Number.isInteger(tick) ? String(tick) : tick.toFixed(2).replace(/0$/, "");
       return `<g>
-                <path class="open-result-objective-grid" d="M${panel.left} ${y.toFixed(1)} H${panel.right}" />
-                <text class="open-result-axis-tick open-result-objective-y-label" x="${panel.left - 14}" y="${(y + 4).toFixed(1)}">${label}</text>
+                <path class="result-objective-grid" d="M${panel.left} ${y.toFixed(1)} H${panel.right}" />
+                <text class="result-axis-tick result-objective-y-label" x="${panel.left - 14}" y="${(y + 4).toFixed(1)}">${label}</text>
               </g>`;
     }).join("\n");
   const marks = rule.nodes
@@ -776,26 +776,26 @@ function ruleDistributionFigure({ rule, figureNumber, title, subtitle, markerCla
                 <circle cx="${x.toFixed(1)}" cy="${y.toFixed(1)}" r="${visibleRadius.toFixed(1)}" />
               </g>`;
     }).join("\n");
-  return `<figure class="open-result-primer-card open-result-paper-figure open-result-single-rule-figure" id="fig-${figureNumber}">
-          <svg class="open-result-primer-svg open-result-accepted-rule-svg open-result-paper-chart-svg" viewBox="0 0 560 280" role="img" aria-label="${escapeHtml(ariaLabel)}">
-            <text class="open-result-axis-label open-result-objective-y-title" x="34" y="${top + panel.height / 2}" transform="rotate(-90 34 ${top + panel.height / 2})">normalized weight w<tspan baseline-shift="sub" font-size="8">i</tspan></text>
-            <g class="open-result-objective-legend open-result-single-rule-legend" transform="translate(${panel.right - 92} 34)">
+  return `<figure class="result-primer-card result-paper-figure result-single-rule-figure" id="fig-${figureNumber}">
+          <svg class="result-primer-svg result-accepted-rule-svg result-paper-chart-svg" viewBox="0 0 560 280" role="img" aria-label="${escapeHtml(ariaLabel)}">
+            <text class="result-axis-label result-objective-y-title" x="34" y="${top + panel.height / 2}" transform="rotate(-90 34 ${top + panel.height / 2})">normalized weight w<tspan baseline-shift="sub" font-size="8">i</tspan></text>
+            <g class="result-objective-legend result-single-rule-legend" transform="translate(${panel.right - 92} 34)">
               <g transform="translate(0 0)">
-                <circle class="${markerClass === "open-result-baseline-node" ? "open-result-legend-baseline-dot" : "open-result-legend-accepted-dot"}" cx="0" cy="0" r="3.8" />
+                <circle class="${markerClass === "result-baseline-node" ? "result-legend-baseline-dot" : "result-legend-accepted-dot"}" cx="0" cy="0" r="3.8" />
                 <text x="16" y="4">${markerLabel}</text>
               </g>
             </g>
-            <g class="open-result-rule-panel">
-              <text class="open-result-axis-label open-result-figure-title" x="${panel.left}" y="36">${title}</text>
+            <g class="result-rule-panel">
+              <text class="result-axis-label result-figure-title" x="${panel.left}" y="36">${title}</text>
 ${subtitleMarkup}
               ${yTickMarkup}
-              <path class="open-result-rule-paper-axis" d="M${panel.left} ${top} V${top + panel.height} H${panel.right}" />
-              <text class="open-result-axis-tick" x="${panel.left}" y="${top + panel.height + 18}">0</text>
-              <text class="open-result-axis-tick" x="${panel.left + panel.width / 2}" y="${top + panel.height + 18}">0.5</text>
-              <text class="open-result-axis-tick" x="${panel.right}" y="${top + panel.height + 18}">1</text>
+              <path class="result-rule-paper-axis" d="M${panel.left} ${top} V${top + panel.height} H${panel.right}" />
+              <text class="result-axis-tick" x="${panel.left}" y="${top + panel.height + 18}">0</text>
+              <text class="result-axis-tick" x="${panel.left + panel.width / 2}" y="${top + panel.height + 18}">0.5</text>
+              <text class="result-axis-tick" x="${panel.right}" y="${top + panel.height + 18}">1</text>
             </g>
             ${marks}
-            <text class="open-result-axis-label open-result-x-axis-title" x="${panel.left + panel.width / 2}" y="260">node position x<tspan baseline-shift="sub" font-size="8">i</tspan></text>
+            <text class="result-axis-label result-x-axis-title" x="${panel.left + panel.width / 2}" y="260">node position x<tspan baseline-shift="sub" font-size="8">i</tspan></text>
           </svg>
           <figcaption>Figure ${figureNumber}. ${caption}</figcaption>
         </figure>`;
@@ -808,7 +808,7 @@ function baselineRulePaperFigure(evolution) {
     figureNumber: 4,
     title: "Run baseline",
     subtitle: "",
-    markerClass: "open-result-baseline-node",
+    markerClass: "result-baseline-node",
     markerLabel: "run baseline",
     ariaLabel: "Run baseline quadrature rule shown as node position and normalized weight.",
     caption: "Run baseline \\(r_0\\). This fixed rule anchors the residual and objective improvements reported later.",
@@ -822,7 +822,7 @@ function acceptedRulePaperFigure(evolution) {
     figureNumber: 5,
     title: "Accepted rule",
     subtitle: "",
-    markerClass: "open-result-accepted-node",
+    markerClass: "result-accepted-node",
     markerLabel: "accepted",
     ariaLabel: "Accepted five node quadrature rule shown as node position and normalized weight.",
     caption: "Accepted five-node rule in node-position and normalized-weight coordinates. The near-uniform weights and inward node placement define the candidate evaluated below.",
@@ -857,7 +857,7 @@ function contractReproducibilityTable(evolution) {
   const baselineErrors = steps[0]?.integrand_error ?? {};
   const names = ["sin_pi", "sqrt", "log1p"].filter((name) => baselineErrors[name] !== undefined);
   return paperTable({
-    className: "open-result-contract-table",
+    className: "result-contract-table",
     caption: "Table 1. Evaluation contract surface. Each row defines one public residual component and the residual of the fixed run baseline.",
     headers: ["Component", "Integrand", "Analytic reference", "Baseline residual"],
     rows: names.map((name, index) => [
@@ -945,52 +945,52 @@ function residualLocationFigure(evolution) {
         .map(([x, curveY]) => `L${x.toFixed(1)} ${curveY.toFixed(1)}`)
         .join(" ");
       const residualRegion = `M${cellX.toFixed(1)} ${y.toFixed(1)} L${(cellX + cellWidth).toFixed(1)} ${y.toFixed(1)} ${highEdge} Z`;
-      return `<g class="open-result-residual-cell">
+      return `<g class="result-residual-cell">
                 <rect x="${cellX.toFixed(1)}" y="${y.toFixed(1)}" width="${cellWidth.toFixed(1)}" height="${(base - y).toFixed(1)}" />
-                <path class="open-result-residual-cell-gap-fill" d="${residualRegion}" />
-                <path class="open-result-residual-cell-gap" d="${residualRegion}" />
+                <path class="result-residual-cell-gap-fill" d="${residualRegion}" />
+                <path class="result-residual-cell-gap" d="${residualRegion}" />
                 <circle cx="${mapX(node).toFixed(1)}" cy="${y.toFixed(1)}" r="3.2" />
               </g>`;
     }).join("\n");
     const baselineY = mapY(fn(baselineNode));
     return `<g transform="translate(0 0)">
-              <text class="open-result-axis-label open-result-figure-title" x="${left}" y="${top}">${integrandSvgLabel(name)}</text>
-              <text class="open-result-axis-label open-result-residual-value" x="414" y="${top + 24}">run baseline e<tspan baseline-shift="sub" font-size="8">j</tspan></text>
-              <text class="open-result-axis-label open-result-residual-number open-result-residual-number-baseline" x="414" y="${top + 43}">${formatMetric(baselineErrors[name], { maximumFractionDigits: 6, minimumFractionDigits: 6 })}</text>
-              <text class="open-result-axis-label open-result-residual-value" x="414" y="${top + 68}">accepted e<tspan baseline-shift="sub" font-size="8">j</tspan></text>
-              <text class="open-result-axis-label open-result-residual-number" x="414" y="${top + 87}">${formatMetric(errors[name], { maximumFractionDigits: 6, minimumFractionDigits: 6 })}</text>
-              <path class="open-result-primer-grid" d="M${left} ${top + 12} V${base} H${right}" />
-              <text class="open-result-axis-tick" x="${left}" y="${base + 18}">0</text>
-              <text class="open-result-axis-tick" x="${right}" y="${base + 18}">1</text>
-              <text class="open-result-axis-label open-result-x-axis-title" x="${left + width / 2}" y="${base + 34}">x<tspan baseline-shift="sub" font-size="8">i</tspan></text>
+              <text class="result-axis-label result-figure-title" x="${left}" y="${top}">${integrandSvgLabel(name)}</text>
+              <text class="result-axis-label result-residual-value" x="414" y="${top + 24}">run baseline e<tspan baseline-shift="sub" font-size="8">j</tspan></text>
+              <text class="result-axis-label result-residual-number result-residual-number-baseline" x="414" y="${top + 43}">${formatMetric(baselineErrors[name], { maximumFractionDigits: 6, minimumFractionDigits: 6 })}</text>
+              <text class="result-axis-label result-residual-value" x="414" y="${top + 68}">accepted e<tspan baseline-shift="sub" font-size="8">j</tspan></text>
+              <text class="result-axis-label result-residual-number" x="414" y="${top + 87}">${formatMetric(errors[name], { maximumFractionDigits: 6, minimumFractionDigits: 6 })}</text>
+              <path class="result-primer-grid" d="M${left} ${top + 12} V${base} H${right}" />
+              <text class="result-axis-tick" x="${left}" y="${base + 18}">0</text>
+              <text class="result-axis-tick" x="${right}" y="${base + 18}">1</text>
+              <text class="result-axis-label result-x-axis-title" x="${left + width / 2}" y="${base + 34}">x<tspan baseline-shift="sub" font-size="8">i</tspan></text>
               ${cells}
-              <g class="open-result-residual-baseline-marker">
+              <g class="result-residual-baseline-marker">
                 <line x1="${mapX(baselineNode).toFixed(1)}" y1="${base}" x2="${mapX(baselineNode).toFixed(1)}" y2="${baselineY.toFixed(1)}" />
                 <circle cx="${mapX(baselineNode).toFixed(1)}" cy="${baselineY.toFixed(1)}" r="3.6" />
               </g>
-              <path class="open-result-primer-curve" d="${curve}" />
+              <path class="result-primer-curve" d="${curve}" />
             </g>`;
   }).join("\n");
 
-  return `<figure class="open-result-primer-card open-result-paper-figure" id="fig-7">
-          <svg class="open-result-primer-svg open-result-residual-location-svg open-result-paper-chart-svg" viewBox="0 0 560 456" role="img" aria-label="Residual location diagnostics for the run baseline and accepted rule on each public integrand.">
+  return `<figure class="result-primer-card result-paper-figure" id="fig-7">
+          <svg class="result-primer-svg result-residual-location-svg result-paper-chart-svg" viewBox="0 0 560 456" role="img" aria-label="Residual location diagnostics for the run baseline and accepted rule on each public integrand.">
             <defs>
               <pattern id="acceptedResidualHatch" patternUnits="userSpaceOnUse" width="10" height="10" patternTransform="rotate(62)">
                 <line x1="0" y1="0" x2="0" y2="10" />
               </pattern>
             </defs>
-            <text class="open-result-axis-label open-result-figure-title" x="${left}" y="34">Residual location diagnostic</text>
-            <g class="open-result-objective-legend" transform="translate(${left} 48)">
+            <text class="result-axis-label result-figure-title" x="${left}" y="34">Residual location diagnostic</text>
+            <g class="result-objective-legend" transform="translate(${left} 48)">
               <g transform="translate(0 0)">
-                <circle class="open-result-legend-baseline-dot" cx="0" cy="0" r="3.4" />
+                <circle class="result-legend-baseline-dot" cx="0" cy="0" r="3.4" />
                 <text x="16" y="4">run baseline sample</text>
               </g>
               <g transform="translate(142 0)">
-                <circle class="open-result-legend-accepted-dot" cx="0" cy="0" r="3.8" />
+                <circle class="result-legend-accepted-dot" cx="0" cy="0" r="3.8" />
                 <text x="16" y="4">accepted samples</text>
               </g>
               <g transform="translate(282 0)">
-                <line class="open-result-objective-legend-best" x1="0" y1="0" x2="18" y2="0" />
+                <line class="result-objective-legend-best" x1="0" y1="0" x2="18" y2="0" />
                 <text x="26" y="4">integrand curve</text>
               </g>
             </g>
@@ -1031,57 +1031,57 @@ function objectiveCurveFigure(evolution) {
     .map((value) => {
       const x = mapX(value);
       return `<g>
-                <path class="open-result-objective-x-tick" d="M${x.toFixed(1)} ${bottom} V${(bottom + 5).toFixed(1)}" />
-                <text class="open-result-axis-tick" x="${x.toFixed(1)}" y="${bottom + 22}">${value}</text>
+                <path class="result-objective-x-tick" d="M${x.toFixed(1)} ${bottom} V${(bottom + 5).toFixed(1)}" />
+                <text class="result-axis-tick" x="${x.toFixed(1)}" y="${bottom + 22}">${value}</text>
               </g>`;
     }).join("\n");
   const proposalDots = scored.map((step) => {
     const x = mapX(step.index ?? 0);
     const y = mapY(step.score);
-    return `<circle class="open-result-objective-proposal" cx="${x.toFixed(1)}" cy="${y.toFixed(1)}" r="2.1" />`;
+    return `<circle class="result-objective-proposal" cx="${x.toFixed(1)}" cy="${y.toFixed(1)}" r="2.1" />`;
   }).join("\n");
   const grid = [0, 200, 400, 600, maxScore]
     .filter((value, index, values) => value <= maxScore && values.indexOf(value) === index)
     .map((value) => {
       const y = mapY(value);
       return `<g>
-                <path class="open-result-objective-grid" d="M${left} ${y.toFixed(1)} H${right}" />
-                <text class="open-result-axis-tick open-result-objective-y-label" x="${left - 18}" y="${(y + 4).toFixed(1)}">${value}</text>
+                <path class="result-objective-grid" d="M${left} ${y.toFixed(1)} H${right}" />
+                <text class="result-axis-tick result-objective-y-label" x="${left - 18}" y="${(y + 4).toFixed(1)}">${value}</text>
               </g>`;
     }).join("\n");
 
-  return `<figure class="open-result-primer-card open-result-paper-figure open-result-objective-figure" id="fig-6">
-          <svg class="open-result-primer-svg open-result-objective-svg" viewBox="0 0 560 328" role="img" aria-label="Best so far objective curve across the curated public trace.">
-            <text class="open-result-axis-label open-result-figure-title" x="${left}" y="34">Best-so-far acceptance objective (lower is better)</text>
-            <g class="open-result-objective-legend" transform="translate(${left} 48)">
+  return `<figure class="result-primer-card result-paper-figure result-objective-figure" id="fig-6">
+          <svg class="result-primer-svg result-objective-svg" viewBox="0 0 560 328" role="img" aria-label="Best so far objective curve across the curated public trace.">
+            <text class="result-axis-label result-figure-title" x="${left}" y="34">Best-so-far acceptance objective (lower is better)</text>
+            <g class="result-objective-legend" transform="translate(${left} 48)">
               <g transform="translate(0 0)">
-                <circle class="open-result-objective-legend-proposal" cx="0" cy="0" r="2.4" />
+                <circle class="result-objective-legend-proposal" cx="0" cy="0" r="2.4" />
                 <text x="12" y="4">scored candidate</text>
               </g>
               <g transform="translate(118 0)">
-                <line class="open-result-objective-legend-best" x1="0" y1="0" x2="16" y2="0" />
+                <line class="result-objective-legend-best" x1="0" y1="0" x2="16" y2="0" />
                 <text x="24" y="4">best-so-far objective</text>
               </g>
               <g transform="translate(286 0)">
-                <circle class="open-result-legend-baseline-dot" cx="0" cy="0" r="3.4" />
+                <circle class="result-legend-baseline-dot" cx="0" cy="0" r="3.4" />
                 <text x="16" y="4">baseline</text>
               </g>
               <g transform="translate(374 0)">
-                <circle class="open-result-legend-accepted-dot" cx="0" cy="0" r="3.8" />
+                <circle class="result-legend-accepted-dot" cx="0" cy="0" r="3.8" />
                 <text x="16" y="4">accepted</text>
               </g>
             </g>
             ${grid}
-            <path class="open-result-rule-paper-axis" d="M${left} ${top} V${bottom} H${right}" />
+            <path class="result-rule-paper-axis" d="M${left} ${top} V${bottom} H${right}" />
             ${xTicks}
-            <text class="open-result-axis-label open-result-x-axis-title" x="${left + width / 2}" y="306">candidate index</text>
-            <text class="open-result-axis-label open-result-objective-y-title" x="34" y="${top + height / 2}" transform="rotate(-90 34 ${top + height / 2})">J(r)</text>
+            <text class="result-axis-label result-x-axis-title" x="${left + width / 2}" y="306">candidate index</text>
+            <text class="result-axis-label result-objective-y-title" x="34" y="${top + height / 2}" transform="rotate(-90 34 ${top + height / 2})">J(r)</text>
             <g>${proposalDots}</g>
-            <path class="open-result-objective-best" d="${svgPolyline(bestPoints)}" />
-            <g class="open-result-objective-baseline">
+            <path class="result-objective-best" d="${svgPolyline(bestPoints)}" />
+            <g class="result-objective-baseline">
               <circle cx="${baselineX.toFixed(1)}" cy="${baselineY.toFixed(1)}" r="4.2" />
             </g>
-            <g class="open-result-objective-accepted">
+            <g class="result-objective-accepted">
               <circle cx="${acceptedX.toFixed(1)}" cy="${acceptedY.toFixed(1)}" r="4.8" />
             </g>
           </svg>
@@ -1090,14 +1090,14 @@ function objectiveCurveFigure(evolution) {
 }
 
 function paperAssetFigure({ src, caption, number }) {
-  return `<figure class="open-result-paper-asset" id="fig-${number}">
+  return `<figure class="result-paper-asset" id="fig-${number}">
           <img src="./${escapeHtml(src)}" alt="">
           <figcaption>Figure ${number}. ${escapeHtml(caption)}</figcaption>
         </figure>`;
 }
 
 function paperInlineFigure({ number, caption, svg, className = "" }) {
-  const classes = ["open-result-primer-card", "open-result-paper-figure", className].filter(Boolean).join(" ");
+  const classes = ["result-primer-card", "result-paper-figure", className].filter(Boolean).join(" ");
   return `<figure class="${classes}" id="fig-${number}">
 ${svg}
           <figcaption>Figure ${number}. ${escapeHtml(caption)}</figcaption>
@@ -1202,7 +1202,7 @@ function pythonImplementationCodeFigure({ source, caption, className = "" }) {
     .map((line, index) => `<span class="code-line"><span class="line-no">${index + 1}</span><span class="line-src">${highlightPythonLine(line)}</span></span>`)
     .join("");
   const extraClass = className ? ` ${className}` : "";
-  return `<figure class="open-result-paper-code open-result-code-figure${extraClass}" id="listing-1">
+  return `<figure class="result-paper-code result-code-figure${extraClass}" id="listing-1">
           <pre><code>${markup}</code></pre>
           <figcaption>Listing 1. ${escapeHtml(caption)}</figcaption>
         </figure>`;
@@ -1292,8 +1292,8 @@ function rcpspScheduleFigure() {
     number: 1,
     caption: "RCPSP schedule readout. The standard schedule view combines the precedence network, Gantt placement, and makespan marker.",
     className: "rcpsp-inline-figure rcpsp-schedule-figure",
-    svg: `          <svg class="open-result-primer-svg rcpsp-paper-svg" viewBox="0 0 560 328" role="img" aria-label="RCPSP schedule readout with precedence network and Gantt schedule.">
-            <text class="open-result-axis-label open-result-figure-title" x="72" y="34">RCPSP schedule readout</text>
+    svg: `          <svg class="result-primer-svg rcpsp-paper-svg" viewBox="0 0 560 328" role="img" aria-label="RCPSP schedule readout with precedence network and Gantt schedule.">
+            <text class="result-axis-label result-figure-title" x="72" y="34">RCPSP schedule readout</text>
             <text class="rcpsp-paper-note" x="72" y="55">Eligible activities are ranked first; the evaluator then commits them to the earliest feasible placement.</text>
             <text class="rcpsp-paper-section-label" x="72" y="82">precedence network</text>
             <g class="rcpsp-network">
@@ -1311,8 +1311,8 @@ function rcpspScheduleFigure() {
             <text class="rcpsp-paper-note" x="72" y="192">A task becomes eligible only after all predecessor arcs are satisfied.</text>
             <text class="rcpsp-paper-section-label" x="72" y="212">Gantt schedule</text>
             <g class="rcpsp-gantt">
-              <path class="open-result-objective-grid" d="M126 234H512M126 256H512M126 278H512" />
-              <path class="open-result-rule-paper-axis" d="M126 292H512" />
+              <path class="result-objective-grid" d="M126 234H512M126 256H512M126 278H512" />
+              <path class="result-rule-paper-axis" d="M126 292H512" />
               <text x="72" y="238">row 1</text>
               <text x="72" y="260">row 2</text>
               <text x="72" y="282">row 3</text>
@@ -1337,12 +1337,12 @@ function rcpspResourceLoadFigure() {
     number: 2,
     caption: "Renewable-resource load profile. The evaluator only accepts placements that keep every active resource demand under the capacity line.",
     className: "rcpsp-inline-figure rcpsp-resource-figure",
-    svg: `          <svg class="open-result-primer-svg rcpsp-paper-svg" viewBox="0 0 560 306" role="img" aria-label="Renewable resource load profile for an RCPSP schedule.">
-            <text class="open-result-axis-label open-result-figure-title" x="72" y="34">Renewable resource load</text>
+    svg: `          <svg class="result-primer-svg rcpsp-paper-svg" viewBox="0 0 560 306" role="img" aria-label="Renewable resource load profile for an RCPSP schedule.">
+            <text class="result-axis-label result-figure-title" x="72" y="34">Renewable resource load</text>
             <text class="rcpsp-paper-note" x="72" y="55">A schedule is feasible only while every time bucket stays at or below capacity.</text>
             <g transform="translate(82 74)">
-              <path class="open-result-objective-grid" d="M42 144H430M42 108H430M42 72H430M42 36H430" />
-              <path class="open-result-rule-paper-axis" d="M42 0V174H430" />
+              <path class="result-objective-grid" d="M42 144H430M42 108H430M42 72H430M42 36H430" />
+              <path class="result-rule-paper-axis" d="M42 0V174H430" />
               <path class="rcpsp-capacity-line" d="M42 54H430" />
               <text class="rcpsp-paper-section-label" x="408" y="46" text-anchor="end">capacity</text>
               <rect class="rcpsp-load" x="55" y="108" width="36" height="66" />
@@ -1354,16 +1354,16 @@ function rcpspResourceLoadFigure() {
               <rect class="rcpsp-load" x="331" y="120" width="36" height="54" />
               <rect class="rcpsp-load" x="377" y="132" width="36" height="42" />
               <rect class="rcpsp-load-window" x="143" y="24" width="92" height="150" />
-              <text class="open-result-axis-tick open-result-objective-y-label" x="30" y="148">0</text>
-              <text class="open-result-axis-tick open-result-objective-y-label" x="30" y="112">1</text>
-              <text class="open-result-axis-tick open-result-objective-y-label" x="30" y="76">2</text>
-              <text class="open-result-axis-tick open-result-objective-y-label" x="30" y="40">3</text>
-              <text class="open-result-axis-tick" x="42" y="196">0</text>
-              <text class="open-result-axis-tick" x="190" y="196">20</text>
-              <text class="open-result-axis-tick" x="337" y="196">40</text>
-              <text class="open-result-axis-tick" x="430" y="196">60</text>
-              <text class="open-result-axis-label open-result-x-axis-title" x="236" y="226">time bucket</text>
-              <text class="open-result-axis-label open-result-objective-y-title" x="0" y="87" transform="rotate(-90 0 87)">active demand</text>
+              <text class="result-axis-tick result-objective-y-label" x="30" y="148">0</text>
+              <text class="result-axis-tick result-objective-y-label" x="30" y="112">1</text>
+              <text class="result-axis-tick result-objective-y-label" x="30" y="76">2</text>
+              <text class="result-axis-tick result-objective-y-label" x="30" y="40">3</text>
+              <text class="result-axis-tick" x="42" y="196">0</text>
+              <text class="result-axis-tick" x="190" y="196">20</text>
+              <text class="result-axis-tick" x="337" y="196">40</text>
+              <text class="result-axis-tick" x="430" y="196">60</text>
+              <text class="result-axis-label result-x-axis-title" x="236" y="226">time bucket</text>
+              <text class="result-axis-label result-objective-y-title" x="0" y="87" transform="rotate(-90 0 87)">active demand</text>
               <text class="rcpsp-paper-note" x="42" y="258">The fixed evaluator rejects any placement that crosses the capacity line.</text>
             </g>
           </svg>`,
@@ -1393,7 +1393,7 @@ function rcpspObjectiveCurveFigure(scoreTrace) {
     .map((candidate) => {
       const generation = candidate.generation ?? 0;
       const score = candidate.score ?? scoreMax;
-      return `<circle class="open-result-objective-proposal${score > scoreMax ? " is-clipped" : ""}" cx="${xAt(generation).toFixed(1)}" cy="${yAt(score).toFixed(1)}" r="1.6" />`;
+      return `<circle class="result-objective-proposal${score > scoreMax ? " is-clipped" : ""}" cx="${xAt(generation).toFixed(1)}" cy="${yAt(score).toFixed(1)}" r="1.6" />`;
     })
     .join("\n              ");
   const fallbackBest = [
@@ -1414,39 +1414,39 @@ function rcpspObjectiveCurveFigure(scoreTrace) {
   const yTicks = [scoreMax, 14, 12]
     .map((tick) => {
       const y = yAt(tick);
-      return `<path class="open-result-objective-grid" d="M${left} ${y.toFixed(1)}H${right}" /><text class="open-result-axis-tick open-result-objective-y-label" x="${left - 14}" y="${(y + 4).toFixed(1)}">${scoreLabel(tick)}</text>`;
+      return `<path class="result-objective-grid" d="M${left} ${y.toFixed(1)}H${right}" /><text class="result-axis-tick result-objective-y-label" x="${left - 14}" y="${(y + 4).toFixed(1)}">${scoreLabel(tick)}</text>`;
     })
     .join("\n            ");
   const xTicks = [0, 40, 80, generationEnd]
     .map((generation, index, all) => {
       const x = xAt(generation);
       const anchor = index === 0 ? "" : index === all.length - 1 ? ' text-anchor="end"' : ' text-anchor="middle"';
-      return `<text class="open-result-axis-tick" x="${x.toFixed(1)}" y="282"${anchor}>${formatMetric(generation, { maximumFractionDigits: 0 })}</text>`;
+      return `<text class="result-axis-tick" x="${x.toFixed(1)}" y="282"${anchor}>${formatMetric(generation, { maximumFractionDigits: 0 })}</text>`;
     })
     .join("\n            ");
   return paperInlineFigure({
     number: 3,
     caption: "Best-so-far score across the curated evolutionary chain, rendered in the same paper style as the quadrature objective trace. Faint points are scored candidates from the sanitized public trace; scores above 16 are clipped at the top of the plotting area.",
-    className: "rcpsp-inline-figure open-result-objective-figure",
-    svg: `          <svg class="open-result-primer-svg open-result-objective-svg rcpsp-paper-svg" viewBox="0 0 560 328" role="img" aria-label="Best-so-far RCPSP acceptance objective.">
-            <text class="open-result-axis-label open-result-figure-title" x="82" y="34">Best-so-far acceptance objective (lower is better)</text>
-            <g class="open-result-objective-legend" transform="translate(82 48)">
-              <g transform="translate(0 0)"><circle class="open-result-objective-legend-proposal" cx="0" cy="0" r="2.4" /><text x="12" y="4">scored candidate</text></g>
-              <g transform="translate(112 0)"><line class="open-result-objective-legend-best" x1="0" y1="0" x2="16" y2="0" /><text x="24" y="4">best-so-far objective</text></g>
-              <g transform="translate(286 0)"><circle class="open-result-legend-baseline-dot" cx="0" cy="0" r="3.4" /><text x="16" y="4">baseline</text></g>
-              <g transform="translate(370 0)"><circle class="open-result-legend-accepted-dot" cx="0" cy="0" r="3.8" /><text x="16" y="4">accepted</text></g>
+    className: "rcpsp-inline-figure result-objective-figure",
+    svg: `          <svg class="result-primer-svg result-objective-svg rcpsp-paper-svg" viewBox="0 0 560 328" role="img" aria-label="Best-so-far RCPSP acceptance objective.">
+            <text class="result-axis-label result-figure-title" x="82" y="34">Best-so-far acceptance objective (lower is better)</text>
+            <g class="result-objective-legend" transform="translate(82 48)">
+              <g transform="translate(0 0)"><circle class="result-objective-legend-proposal" cx="0" cy="0" r="2.4" /><text x="12" y="4">scored candidate</text></g>
+              <g transform="translate(112 0)"><line class="result-objective-legend-best" x1="0" y1="0" x2="16" y2="0" /><text x="24" y="4">best-so-far objective</text></g>
+              <g transform="translate(286 0)"><circle class="result-legend-baseline-dot" cx="0" cy="0" r="3.4" /><text x="16" y="4">baseline</text></g>
+              <g transform="translate(370 0)"><circle class="result-legend-accepted-dot" cx="0" cy="0" r="3.8" /><text x="16" y="4">accepted</text></g>
             </g>
             ${yTicks}
-            <path class="open-result-rule-paper-axis" d="M${left} ${top}V${bottom}H${right}" />
+            <path class="result-rule-paper-axis" d="M${left} ${top}V${bottom}H${right}" />
             <g>
               ${candidateDots}
             </g>
-            <path class="open-result-objective-best" d="${bestPath}" />
-            <g class="open-result-objective-baseline"><circle cx="${xAt(0).toFixed(1)}" cy="${yAt(baselineScore).toFixed(1)}" r="4.2" /></g>
-            <g class="open-result-objective-accepted"><circle cx="${xAt(generationEnd).toFixed(1)}" cy="${yAt(acceptedScore).toFixed(1)}" r="4.8" /></g>
+            <path class="result-objective-best" d="${bestPath}" />
+            <g class="result-objective-baseline"><circle cx="${xAt(0).toFixed(1)}" cy="${yAt(baselineScore).toFixed(1)}" r="4.2" /></g>
+            <g class="result-objective-accepted"><circle cx="${xAt(generationEnd).toFixed(1)}" cy="${yAt(acceptedScore).toFixed(1)}" r="4.8" /></g>
             ${xTicks}
-            <text class="open-result-axis-label open-result-x-axis-title" x="${(left + plotW / 2).toFixed(1)}" y="306">generation <tspan font-style="italic">k</tspan></text>
-            <text class="open-result-axis-label open-result-objective-y-title" x="34" y="${(top + plotH / 2).toFixed(1)}" transform="rotate(-90 34 ${(top + plotH / 2).toFixed(1)})"><tspan font-style="italic">J</tspan><tspan>(</tspan><tspan font-style="italic">r</tspan><tspan>)</tspan></text>
+            <text class="result-axis-label result-x-axis-title" x="${(left + plotW / 2).toFixed(1)}" y="306">generation <tspan font-style="italic">k</tspan></text>
+            <text class="result-axis-label result-objective-y-title" x="34" y="${(top + plotH / 2).toFixed(1)}" transform="rotate(-90 34 ${(top + plotH / 2).toFixed(1)})"><tspan font-style="italic">J</tspan><tspan>(</tspan><tspan font-style="italic">r</tspan><tspan>)</tspan></text>
           </svg>`,
   });
 }
@@ -1464,8 +1464,8 @@ function rcpspBenchmarkComparisonFigure(full) {
     number: 4,
     caption: "Seed versus accepted acceptance-score readout; lower values are better.",
     className: "rcpsp-inline-figure rcpsp-benchmark-figure",
-    svg: `          <svg class="open-result-primer-svg rcpsp-paper-svg" viewBox="0 0 560 220" role="img" aria-label="Seed versus accepted RCPSP acceptance score readout.">
-            <text class="open-result-axis-label open-result-figure-title" x="48" y="34">Acceptance objective</text>
+    svg: `          <svg class="result-primer-svg rcpsp-paper-svg" viewBox="0 0 560 220" role="img" aria-label="Seed versus accepted RCPSP acceptance score readout.">
+            <text class="result-axis-label result-figure-title" x="48" y="34">Acceptance objective</text>
             <text class="rcpsp-paper-note" x="512" y="34" text-anchor="end">lower is better</text>
             <g class="rcpsp-score-readout">
               <path class="rcpsp-reduction-bracket" d="M${bestX.toFixed(1)} 64H${seedX.toFixed(1)}M${bestX.toFixed(1)} 59V69M${seedX.toFixed(1)} 59V69" />
@@ -1479,10 +1479,10 @@ function rcpspBenchmarkComparisonFigure(full) {
               <text class="rcpsp-paper-value" x="512" y="110" text-anchor="end">${formatMetric(seed, { maximumFractionDigits: 3, minimumFractionDigits: 3 })}</text>
               <text class="rcpsp-paper-note" x="${bestX.toFixed(1)}" y="140" text-anchor="middle">accepted</text>
               <text class="rcpsp-paper-value" x="${bestX.toFixed(1)}" y="158" text-anchor="middle">${formatMetric(best, { maximumFractionDigits: 3, minimumFractionDigits: 3 })}</text>
-              <path class="open-result-rule-paper-axis" d="M${scoreTrackX} 176H${scoreTrackX + scoreTrackWidth}" />
-              <text class="open-result-axis-tick" x="${scoreTrackX}" y="196">0</text>
-              <text class="open-result-axis-tick" x="${(scoreTrackX + scoreTrackWidth / 2).toFixed(1)}" y="196" text-anchor="middle">7.5</text>
-              <text class="open-result-axis-tick" x="${(scoreTrackX + scoreTrackWidth).toFixed(1)}" y="196" text-anchor="middle">15</text>
+              <path class="result-rule-paper-axis" d="M${scoreTrackX} 176H${scoreTrackX + scoreTrackWidth}" />
+              <text class="result-axis-tick" x="${scoreTrackX}" y="196">0</text>
+              <text class="result-axis-tick" x="${(scoreTrackX + scoreTrackWidth / 2).toFixed(1)}" y="196" text-anchor="middle">7.5</text>
+              <text class="result-axis-tick" x="${(scoreTrackX + scoreTrackWidth).toFixed(1)}" y="196" text-anchor="middle">15</text>
             </g>
           </svg>`,
   });
@@ -1495,8 +1495,8 @@ function rcpspScheduleCompressionFigure(scheduleExample) {
       number: 5,
       caption: "Real schedule-compression readout unavailable.",
       className: "rcpsp-inline-figure rcpsp-compression-figure",
-      svg: `          <svg class="open-result-primer-svg rcpsp-paper-svg" viewBox="0 0 560 160" role="img" aria-label="RCPSP schedule example unavailable.">
-            <text class="open-result-axis-label open-result-figure-title" x="60" y="48">Schedule example unavailable</text>
+      svg: `          <svg class="result-primer-svg rcpsp-paper-svg" viewBox="0 0 560 160" role="img" aria-label="RCPSP schedule example unavailable.">
+            <text class="result-axis-label result-figure-title" x="60" y="48">Schedule example unavailable</text>
           </svg>`,
     });
   }
@@ -1573,37 +1573,37 @@ function rcpspScheduleCompressionFigure(scheduleExample) {
     number: 5,
     caption: `Real schedule-compression readout for PSPLIB J30 instance ${escapeHtml(example.instance_id)}. All executable jobs are rendered as unlabeled bars; seed finishes at ${formatMetric(example.seed_makespan, { maximumFractionDigits: 0 })}, accepted at ${formatMetric(example.accepted_makespan, { maximumFractionDigits: 0 })}, and the proven optimum is ${formatMetric(example.optimal_makespan, { maximumFractionDigits: 0 })}.`,
     className: "rcpsp-inline-figure rcpsp-compression-figure",
-    svg: `          <svg class="open-result-primer-svg rcpsp-paper-svg" viewBox="0 0 560 438" role="img" aria-label="Real RCPSP schedule compression and renewable resource load readout for ${escapeHtml(example.instance_id)}.">
-            <text class="open-result-axis-label open-result-figure-title" x="60" y="34">Schedule compression</text>
-            <g class="open-result-objective-legend" transform="translate(60 64)">
+    svg: `          <svg class="result-primer-svg rcpsp-paper-svg" viewBox="0 0 560 438" role="img" aria-label="Real RCPSP schedule compression and renewable resource load readout for ${escapeHtml(example.instance_id)}.">
+            <text class="result-axis-label result-figure-title" x="60" y="34">Schedule compression</text>
+            <g class="result-objective-legend" transform="translate(60 64)">
               <g><rect class="rcpsp-gantt-seed" x="0" y="-8" width="16" height="8" /><text x="24" y="0">seed</text></g>
               <g transform="translate(94 0)"><rect class="rcpsp-accent-fill" x="0" y="-8" width="16" height="8" /><text x="24" y="0">accepted</text></g>
               <g transform="translate(238 0)"><line class="rcpsp-capacity-line" x1="0" y1="-4" x2="28" y2="-4" /><text x="36" y="0">capacity</text></g>
             </g>
             <g class="rcpsp-gantt">
               <text class="rcpsp-paper-section-label" x="60" y="88">all executable jobs (${formatMetric(example.executable_job_count ?? executableJobs.length, { maximumFractionDigits: 0 })} bars; ${formatMetric(example.job_count, { maximumFractionDigits: 0 })} including source/sink)</text>
-              <path class="open-result-objective-grid" d="${laneLines}" />
+              <path class="result-objective-grid" d="${laneLines}" />
 ${jobBars}
               <line class="rcpsp-marker-line rcpsp-accepted-marker" x1="${acceptedX.toFixed(1)}" y1="${(ganttTop - 10).toFixed(1)}" x2="${acceptedX.toFixed(1)}" y2="${(axisY - 4).toFixed(1)}" />
               <line class="rcpsp-marker-line" x1="${seedX.toFixed(1)}" y1="${(ganttTop - 10).toFixed(1)}" x2="${seedX.toFixed(1)}" y2="${(axisY - 4).toFixed(1)}" />
-              <path class="open-result-rule-paper-axis" d="M${left} ${axisY}H${right}" />
-              ${xTicks.map((tick, index) => `<text class="open-result-axis-tick" x="${timeX(tick).toFixed(1)}" y="${axisY + 20}" ${index === 0 ? "" : index === xTicks.length - 1 ? 'text-anchor="end"' : 'text-anchor="middle"'}>${formatMetric(tick, { maximumFractionDigits: 0 })}</text>`).join("\n              ")}
+              <path class="result-rule-paper-axis" d="M${left} ${axisY}H${right}" />
+              ${xTicks.map((tick, index) => `<text class="result-axis-tick" x="${timeX(tick).toFixed(1)}" y="${axisY + 20}" ${index === 0 ? "" : index === xTicks.length - 1 ? 'text-anchor="end"' : 'text-anchor="middle"'}>${formatMetric(tick, { maximumFractionDigits: 0 })}</text>`).join("\n              ")}
               <text class="rcpsp-paper-note" x="${acceptedX.toFixed(1)}" y="${axisY + 38}" text-anchor="middle">accepted Cmax</text>
               <text class="rcpsp-paper-note" x="${seedX.toFixed(1)}" y="${axisY + 38}" text-anchor="middle">seed Cmax</text>
             </g>
             <g>
               <text class="rcpsp-paper-section-label" x="60" y="${loadTop - 20}">Resource ${formatMetric((example.resource_index ?? 0) + 1, { maximumFractionDigits: 0 })} full-instance load</text>
-              <path class="open-result-rule-paper-axis" d="M${loadLeft} ${loadTop}V${loadBase}H${loadRight}" />
-              <path class="open-result-objective-grid" d="M${loadLeft} ${loadTop}H${loadRight}" />
+              <path class="result-rule-paper-axis" d="M${loadLeft} ${loadTop}V${loadBase}H${loadRight}" />
+              <path class="result-objective-grid" d="M${loadLeft} ${loadTop}H${loadRight}" />
               <path class="rcpsp-capacity-line" d="M${loadLeft} ${loadTop}H${loadRight}" />
               <text class="rcpsp-paper-note" x="${loadRight}" y="${loadTop - 8}" text-anchor="end">capacity ${formatMetric(capacity, { maximumFractionDigits: 0 })}</text>
 ${resourceBars}
-              <text class="open-result-axis-tick" x="${loadLeft - 10}" y="${loadBase + 3}" text-anchor="end">0</text>
-              <text class="open-result-axis-tick" x="${loadLeft - 10}" y="${loadTop + 3}" text-anchor="end">cap</text>
-              <text class="open-result-axis-tick" x="${loadLeft}" y="${loadBase + 20}">${formatMetric(axisStart, { maximumFractionDigits: 0 })}</text>
-              <text class="open-result-axis-tick" x="${(loadLeft + loadRight) / 2}" y="${loadBase + 20}" text-anchor="middle">time</text>
-              <text class="open-result-axis-tick" x="${loadRight}" y="${loadBase + 20}" text-anchor="end">${formatMetric(axisEnd, { maximumFractionDigits: 0 })}</text>
-              <text class="open-result-axis-label open-result-objective-y-title" x="28" y="${(loadTop + loadBase) / 2}" transform="rotate(-90 28 ${(loadTop + loadBase) / 2})">demand</text>
+              <text class="result-axis-tick" x="${loadLeft - 10}" y="${loadBase + 3}" text-anchor="end">0</text>
+              <text class="result-axis-tick" x="${loadLeft - 10}" y="${loadTop + 3}" text-anchor="end">cap</text>
+              <text class="result-axis-tick" x="${loadLeft}" y="${loadBase + 20}">${formatMetric(axisStart, { maximumFractionDigits: 0 })}</text>
+              <text class="result-axis-tick" x="${(loadLeft + loadRight) / 2}" y="${loadBase + 20}" text-anchor="middle">time</text>
+              <text class="result-axis-tick" x="${loadRight}" y="${loadBase + 20}" text-anchor="end">${formatMetric(axisEnd, { maximumFractionDigits: 0 })}</text>
+              <text class="result-axis-label result-objective-y-title" x="28" y="${(loadTop + loadBase) / 2}" transform="rotate(-90 28 ${(loadTop + loadBase) / 2})">demand</text>
             </g>
           </svg>`,
   });
@@ -1630,8 +1630,8 @@ function rcpspGapSummaryFigure(full) {
     number: 6,
     caption: "Accepted candidate diagnostics on the frozen 80-instance portfolio.",
     className: "rcpsp-inline-figure rcpsp-gap-figure",
-    svg: `          <svg class="open-result-primer-svg rcpsp-paper-svg" viewBox="0 0 560 280" role="img" aria-label="Accepted RCPSP gap diagnostics.">
-            <text class="open-result-axis-label open-result-figure-title" x="72" y="34">Accepted candidate diagnostics</text>
+    svg: `          <svg class="result-primer-svg rcpsp-paper-svg" viewBox="0 0 560 280" role="img" aria-label="Accepted RCPSP gap diagnostics.">
+            <text class="result-axis-label result-figure-title" x="72" y="34">Accepted candidate diagnostics</text>
             <text class="rcpsp-paper-note" x="488" y="34" text-anchor="end">80 frozen PSPLIB J30 instances</text>
 ${rows}
             <text class="rcpsp-paper-note" x="72" y="252">Feasibility penalty: 0.000 | invalid priority count: 0 | schedules validated: 80 / 80</text>
@@ -1655,16 +1655,16 @@ function rcpspTailLadderFigure(evolution) {
     number: 7,
     caption: "Worst-instance tail behavior for the accepted candidate. Each bar shows residual gap against the proven optimum.",
     className: "rcpsp-inline-figure rcpsp-tail-figure",
-    svg: `          <svg class="open-result-primer-svg rcpsp-paper-svg" viewBox="0 0 560 328" role="img" aria-label="Worst accepted RCPSP gaps.">
-            <text class="open-result-axis-label open-result-figure-title" x="72" y="34">Tail behavior kept visible</text>
+    svg: `          <svg class="result-primer-svg rcpsp-paper-svg" viewBox="0 0 560 328" role="img" aria-label="Worst accepted RCPSP gaps.">
+            <text class="result-axis-label result-figure-title" x="72" y="34">Tail behavior kept visible</text>
             <text class="rcpsp-paper-note" x="488" y="34" text-anchor="end">largest accepted-candidate gaps</text>
-            <path class="open-result-rule-paper-axis" d="M170 50V250H512" />
-            <path class="open-result-objective-grid" d="M270 50V250M370 50V250M470 50V250" />
+            <path class="result-rule-paper-axis" d="M170 50V250H512" />
+            <path class="result-objective-grid" d="M270 50V250M370 50V250M470 50V250" />
 ${bars}
-            <text class="open-result-axis-tick" x="170" y="276">0%</text>
-            <text class="open-result-axis-tick" x="270" y="276">8%</text>
-            <text class="open-result-axis-tick" x="370" y="276">16%</text>
-            <text class="open-result-axis-tick" x="470" y="276">24%</text>
+            <text class="result-axis-tick" x="170" y="276">0%</text>
+            <text class="result-axis-tick" x="270" y="276">8%</text>
+            <text class="result-axis-tick" x="370" y="276">16%</text>
+            <text class="result-axis-tick" x="470" y="276">24%</text>
             <text class="rcpsp-paper-note" x="72" y="306">Worst residual gaps remain part of the public result definition.</text>
           </svg>`,
   });
@@ -1700,28 +1700,28 @@ function acceptedRuleVisual(full, evolution) {
       const weight = rule.weights[index] ?? 0;
       const x = Math.min(100, Math.max(0, node * 100));
       const bar = maxWeight > 0 ? Math.max(1.2, (weight / maxWeight) * 5.8) : 1.2;
-      return `<div class="open-result-node" style="--x: ${x.toFixed(3)}%; --bar: ${bar.toFixed(3)}rem;">
-              <span class="open-result-node-pin" aria-hidden="true"></span>
-              <span class="open-result-node-label">${formatMetric(node, { maximumFractionDigits: 3, minimumFractionDigits: 3 })}</span>
-              <span class="open-result-node-weight">${formatMetric(weight, { maximumFractionDigits: 3, minimumFractionDigits: 3 })}</span>
+      return `<div class="result-node" style="--x: ${x.toFixed(3)}%; --bar: ${bar.toFixed(3)}rem;">
+              <span class="result-node-pin" aria-hidden="true"></span>
+              <span class="result-node-label">${formatMetric(node, { maximumFractionDigits: 3, minimumFractionDigits: 3 })}</span>
+              <span class="result-node-weight">${formatMetric(weight, { maximumFractionDigits: 3, minimumFractionDigits: 3 })}</span>
             </div>`;
     })
     .join("\n");
 
-  return `<section class="open-result-rule-visual" aria-label="Accepted quadrature rule visual">
-          <div class="open-result-rule-copy">
+  return `<section class="result-rule-visual" aria-label="Accepted quadrature rule visual">
+          <div class="result-rule-copy">
             <p class="eyebrow">Accepted rule</p>
             <h2>Accepted five-node rule.</h2>
             <p>The final candidate is not a black-box policy. It is a compact rule on the unit interval, with two nodes pulled in from the endpoints, a midpoint node, symmetric interior support, and near-uniform weights.</p>
           </div>
-          <div class="open-result-rule-panel">
-            <div class="open-result-rule-axis" aria-hidden="true">
-              <span class="open-result-axis-end open-result-axis-start">0</span>
-              <span class="open-result-axis-line"></span>
-              <span class="open-result-axis-end open-result-axis-finish">1</span>
+          <div class="result-rule-panel">
+            <div class="result-rule-axis" aria-hidden="true">
+              <span class="result-axis-end result-axis-start">0</span>
+              <span class="result-axis-line"></span>
+              <span class="result-axis-end result-axis-finish">1</span>
 ${nodes}
             </div>
-            <div class="open-result-rule-summary">
+            <div class="result-rule-summary">
               <div>
                 <span>Left endpoint gap</span>
                 <strong>${formatMetric(leftGap, { maximumFractionDigits: 3, minimumFractionDigits: 3 })}</strong>
@@ -1773,8 +1773,8 @@ function resultEvidence(full, evolution) {
       ];
 
   const ruleTable = finalRule?.nodes?.length
-    ? `<div class="open-result-table-wrap">
-          <table class="open-result-table">
+    ? `<div class="result-table-wrap">
+          <table class="result-table">
             <thead>
               <tr>
                 <th>Node</th>
@@ -1805,8 +1805,8 @@ ${finalRule.nodes
     .join("\n");
 
   const errorTable = errorRows
-    ? `<div class="open-result-table-wrap">
-          <table class="open-result-table">
+    ? `<div class="result-table-wrap">
+          <table class="result-table">
             <thead>
               <tr>
                 <th>Integrand</th>
@@ -1853,16 +1853,16 @@ ${errorRows}
       : "",
   ].filter(Boolean);
 
-  return `<section class="open-result-evidence" aria-label="Result evidence">
-          <div class="open-result-evidence-heading">
+  return `<section class="result-evidence" aria-label="Result evidence">
+          <div class="result-evidence-heading">
             <p class="eyebrow">Evidence</p>
             <h2>Acceptance score and observable behavior.</h2>
             ${scoreNote ? `<p>${escapeHtml(scoreNote)}</p>` : ""}
           </div>
-          <div class="open-result-metric-grid">
+          <div class="result-metric-grid">
 ${stats
   .map(
-    ([label, value]) => `            <div class="open-result-metric-card">
+    ([label, value]) => `            <div class="result-metric-card">
               <span>${escapeHtml(label)}</span>
               <strong>${value}</strong>
             </div>`,
@@ -1871,7 +1871,7 @@ ${stats
           </div>
           ${
             panels.length
-              ? `<div class="open-result-data-grid open-result-data-grid-${panels.length}">
+              ? `<div class="result-data-grid result-data-grid-${panels.length}">
 ${panels.join("\n")}
           </div>`
               : ""
@@ -1914,7 +1914,7 @@ async function writeDetail(result) {
 
   const figures = plots
     .map(
-      (plot) => `<figure class="open-result-figure">
+      (plot) => `<figure class="result-figure">
             <img src="./${escapeHtml(plot)}" alt="">
             ${
               full.website?.figure_captions?.[plot]
@@ -1928,35 +1928,35 @@ async function writeDetail(result) {
   const isQuadratureWhitepaper = full.slug === "quadrature-rule-optimization";
   const isRcpspWhitepaper = full.slug === "rcpsp-psplib-j30";
   const body = isQuadratureWhitepaper
-    ? `        <section class="hero compact-hero page-hero open-result-detail-hero">
+    ? `        <section class="hero compact-hero page-hero result-detail-hero">
           <h1 class="page-title">${escapeHtml(full.title)}</h1>
           <p class="intro results-hero-intro">${escapeHtml(full.summary)}</p>
         </section>
 
-        <section class="open-result-detail open-result-whitepaper-shell">
-          <article class="open-result-article open-result-whitepaper">
+        <section class="result-detail result-whitepaper-shell">
+          <article class="result-article result-whitepaper">
 ${markdownToHtml(articleWithoutTitle(article), quadratureWhitepaperInserts(full, evolution, candidateCode))}
           </article>
         </section>`
     : isRcpspWhitepaper
-      ? `        <section class="hero compact-hero page-hero open-result-detail-hero rcpsp-detail-hero">
+      ? `        <section class="hero compact-hero page-hero result-detail-hero rcpsp-detail-hero">
           <h1 class="page-title">${escapeHtml(full.title)}</h1>
           <p class="intro results-hero-intro">${escapeHtml(full.summary)}</p>
         </section>
 
-        <section class="open-result-detail open-result-whitepaper-shell rcpsp-whitepaper-shell">
-          <article class="open-result-article open-result-whitepaper rcpsp-whitepaper">
+        <section class="result-detail result-whitepaper-shell rcpsp-whitepaper-shell">
+          <article class="result-article result-whitepaper rcpsp-whitepaper">
 ${markdownToHtml(articleWithoutTitle(article), rcpspWhitepaperInserts(full, evolution, candidateCode, scheduleExample, scoreTrace))}
           </article>
         </section>`
-    : `        <section class="hero compact-hero page-hero open-result-detail-hero">
+    : `        <section class="hero compact-hero page-hero result-detail-hero">
           <p class="eyebrow">${escapeHtml(full.domain)}</p>
           <h1 class="page-title">${escapeHtml(full.title)}</h1>
           <p class="intro results-hero-intro">${escapeHtml(full.summary)}</p>
         </section>
 
-        <section class="open-result-detail">
-          <article class="open-result-article">
+        <section class="result-detail">
+          <article class="result-article">
 ${markdownToHtml(articleWithoutTitle(article), quadratureProblemVisuals(full, evolution))}
           </article>
         </section>
@@ -1965,14 +1965,14 @@ ${markdownToHtml(articleWithoutTitle(article), quadratureProblemVisuals(full, ev
 
         ${resultSnapshot(full, evolution)}
 
-        <section class="open-result-assets" aria-label="Public result figures">
+        <section class="result-assets" aria-label="Public result figures">
 ${figures}
         </section>
 
         ${resultEvidence(full, evolution)}
 
-        <section class="open-result-code" aria-label="Accepted candidate code">
-          <div class="open-result-code-heading">
+        <section class="result-code" aria-label="Accepted candidate code">
+          <div class="result-code-heading">
             <p class="eyebrow">Accepted implementation</p>
             <h2>Replayable candidate code.</h2>
           </div>
@@ -1989,9 +1989,9 @@ ${figures}
       body,
       enableMath: /\$\$|\\\(|\\\[/.test(article),
       bodyClass: isQuadratureWhitepaper
-        ? "open-result-quadrature-page"
+        ? "result-quadrature-page"
         : isRcpspWhitepaper
-          ? "open-result-rcpsp-page"
+          ? "result-rcpsp-page"
           : "",
     }),
     "utf8",


### PR DESCRIPTION
## Summary\n- Rename generated website classes from `open-result-*` to `result-*`\n- Update the result page generator to emit the cleaned class names\n- Regenerate published result pages and copied result artifacts from `gother-labs-results`\n\n## Validation\n- `node tools/sync-results.mjs`\n- `node --check tools/sync-results.mjs`\n- `node --check scripts.js`\n- `node --check results/quadrature-rule-optimization/run/surface.js`\n- `node --check results/rcpsp-psplib-j30/run/surface.js`\n- Parsed key HTML pages\n- Smoke-tested key local routes with Python urllib\n- Verified no `open-result` / `open-results` references remain