### PR TITLE
Refine results cards and animated site navigation

### DIFF
--- a/404.html
+++ b/404.html
@@ -8,18 +8,35 @@
     <meta name="robots" content="noindex">
     <link rel="preload" href="/assets/fonts/inter-latin.woff2" as="font" type="font/woff2" crossorigin>
     <link rel="icon" href="./assets/gother-mark.svg" type="image/svg+xml">
-    <link rel="stylesheet" href="./styles.css">
+    <link rel="stylesheet" href="./styles.css?v=nav-wordmark-v1">
   </head>
   <body class="not-found-page">
     <a class="skip-link" href="#site-main">Skip to content</a>
     <div class="page-shell site-shell">
       <header class="site-header">
         <nav class="site-nav" aria-label="Primary">
-          <a class="brand nav-brand" href="./" aria-label="Göther Labs home">
-            <img src="./assets/gother-mark.svg" alt="" class="brand-image">
+          <a class="brand nav-brand nav-home-wordmark animated-symbol-scope" href="./" aria-label="Göther Labs home">
+            <span aria-hidden="true" class="wordmark-mark-wrap">
+              <svg class="animated-reference-geometry live-symbol-svg" viewBox="0 0 64 64" focusable="false">
+                <g class="source-geometry" aria-hidden="true">
+                  <circle class="source-geometry-dot" cx="34.5" cy="34.5" r="3.6" />
+                  <circle class="source-geometry-dot" cx="21" cy="58" r="3.6" />
+                  <circle class="source-geometry-dot" cx="48" cy="58" r="3.6" />
+                </g>
+                <path class="live-trail" d="" />
+                <path class="live-trail" d="" />
+                <path class="live-trail" d="" />
+                <circle class="geometry-dot live-geometry-dot" cx="34.2" cy="28.4" r="3.34" />
+                <circle class="geometry-dot live-geometry-dot" cx="20.9" cy="50.6" r="3.34" />
+                <circle class="geometry-dot live-geometry-dot" cx="47.5" cy="50.6" r="3.34" />
+              </svg>
+            </span>
+            <span class="nav-wordmark-text">Göther Labs</span>
           </a>
-          <a href="./company/">Company</a>
-          <a href="./contact/">Contact</a>
+          <div class="nav-links">
+            <a href="./company/">Company</a>
+            <a href="./contact/">Contact</a>
+          </div>
         </nav>
       </header>
 
@@ -55,6 +72,6 @@
       </main>
     </div>
 
-    <script src="./scripts.js"></script>
+    <script src="./scripts.js?v=nav-wordmark-v1"></script>
   </body>
 </html>

--- a/company/index.html
+++ b/company/index.html
@@ -21,19 +21,36 @@
     <meta name="twitter:image" content="https://www.gotherlabs.com/assets/og-image.png">
     <link rel="preload" href="/assets/fonts/inter-latin.woff2" as="font" type="font/woff2" crossorigin>
     <link rel="icon" href="../assets/gother-mark.svg" type="image/svg+xml">
-    <link rel="stylesheet" href="../styles.css?v=site-gutters-v1">
+    <link rel="stylesheet" href="../styles.css?v=nav-wordmark-v1">
   </head>
   <body>
     <a class="skip-link" href="#site-main">Skip to content</a>
     <div class="page-shell site-shell">
       <header class="site-header">
         <nav class="site-nav" aria-label="Primary">
-          <a class="brand nav-brand" href="../" aria-label="Göther Labs home">
-            <img src="../assets/gother-mark.svg" alt="" class="brand-image">
+          <a class="brand nav-brand nav-home-wordmark animated-symbol-scope" href="../" aria-label="Göther Labs home">
+            <span aria-hidden="true" class="wordmark-mark-wrap">
+              <svg class="animated-reference-geometry live-symbol-svg" viewBox="0 0 64 64" focusable="false">
+                <g class="source-geometry" aria-hidden="true">
+                  <circle class="source-geometry-dot" cx="34.5" cy="34.5" r="3.6" />
+                  <circle class="source-geometry-dot" cx="21" cy="58" r="3.6" />
+                  <circle class="source-geometry-dot" cx="48" cy="58" r="3.6" />
+                </g>
+                <path class="live-trail" d="" />
+                <path class="live-trail" d="" />
+                <path class="live-trail" d="" />
+                <circle class="geometry-dot live-geometry-dot" cx="34.2" cy="28.4" r="3.34" />
+                <circle class="geometry-dot live-geometry-dot" cx="20.9" cy="50.6" r="3.34" />
+                <circle class="geometry-dot live-geometry-dot" cx="47.5" cy="50.6" r="3.34" />
+              </svg>
+            </span>
+            <span class="nav-wordmark-text">Göther Labs</span>
           </a>
-          <a href="./">Company</a>
-          <a href="../results/">Results</a>
-          <a href="../contact/">Contact</a>
+          <div class="nav-links">
+            <a href="./">Company</a>
+            <a href="../results/">Results</a>
+            <a href="../contact/">Contact</a>
+          </div>
         </nav>
       </header>
 
@@ -95,7 +112,7 @@
           <article class="content-block">
             <h2>What sits behind the work</h2>
             <p>
-              Inside the company, we use the name <a href="../evolther/" aria-label="Read how Evölther operates"><span class="company-manifesto-inline">Evölther</span></a> for the governed improvement loop behind this direction. It matters to Göther, but it is not the company story by itself. It is the internal system that helps us pursue serious technical gains without sacrificing auditability, judgment, or the trust required to operate them.
+              Inside the company, we use the name <span class="company-manifesto-inline">Evölther</span> for the governed improvement loop behind this direction. It matters to Göther, but it is not the company story by itself. It is the internal system that helps us pursue serious technical gains without sacrificing auditability, judgment, or the trust required to operate them.
             </p>
           </article>
 
@@ -114,6 +131,6 @@
       </footer>
     </div>
 
-    <script src="../scripts.js"></script>
+    <script src="../scripts.js?v=nav-wordmark-v1"></script>
   </body>
 </html>

--- a/contact/index.html
+++ b/contact/index.html
@@ -21,19 +21,36 @@
     <meta name="twitter:image" content="https://www.gotherlabs.com/assets/og-image.png">
     <link rel="preload" href="/assets/fonts/inter-latin.woff2" as="font" type="font/woff2" crossorigin>
     <link rel="icon" href="../assets/gother-mark.svg" type="image/svg+xml">
-    <link rel="stylesheet" href="../styles.css?v=site-gutters-v1">
+    <link rel="stylesheet" href="../styles.css?v=nav-wordmark-v1">
   </head>
   <body>
     <a class="skip-link" href="#site-main">Skip to content</a>
     <div class="page-shell site-shell">
       <header class="site-header">
         <nav class="site-nav" aria-label="Primary">
-          <a class="brand nav-brand" href="../" aria-label="Göther Labs home">
-            <img src="../assets/gother-mark.svg" alt="" class="brand-image">
+          <a class="brand nav-brand nav-home-wordmark animated-symbol-scope" href="../" aria-label="Göther Labs home">
+            <span aria-hidden="true" class="wordmark-mark-wrap">
+              <svg class="animated-reference-geometry live-symbol-svg" viewBox="0 0 64 64" focusable="false">
+                <g class="source-geometry" aria-hidden="true">
+                  <circle class="source-geometry-dot" cx="34.5" cy="34.5" r="3.6" />
+                  <circle class="source-geometry-dot" cx="21" cy="58" r="3.6" />
+                  <circle class="source-geometry-dot" cx="48" cy="58" r="3.6" />
+                </g>
+                <path class="live-trail" d="" />
+                <path class="live-trail" d="" />
+                <path class="live-trail" d="" />
+                <circle class="geometry-dot live-geometry-dot" cx="34.2" cy="28.4" r="3.34" />
+                <circle class="geometry-dot live-geometry-dot" cx="20.9" cy="50.6" r="3.34" />
+                <circle class="geometry-dot live-geometry-dot" cx="47.5" cy="50.6" r="3.34" />
+              </svg>
+            </span>
+            <span class="nav-wordmark-text">Göther Labs</span>
           </a>
-          <a href="../company/">Company</a>
-          <a href="../results/">Results</a>
-          <a href="./">Contact</a>
+          <div class="nav-links">
+            <a href="../company/">Company</a>
+            <a href="../results/">Results</a>
+            <a href="./">Contact</a>
+          </div>
         </nav>
       </header>
 
@@ -94,6 +111,6 @@
       </footer>
     </div>
 
-    <script src="../scripts.js"></script>
+    <script src="../scripts.js?v=nav-wordmark-v1"></script>
   </body>
 </html>

--- a/evolther/index.html
+++ b/evolther/index.html
@@ -11,7 +11,7 @@
     <meta name="robots" content="noindex, nofollow">
     <link rel="preload" href="/assets/fonts/inter-latin.woff2" as="font" type="font/woff2" crossorigin>
     <link rel="icon" href="../assets/gother-mark.svg" type="image/svg+xml">
-    <link rel="stylesheet" href="../styles.css">
+    <link rel="stylesheet" href="../styles.css?v=nav-wordmark-v1">
     <link rel="stylesheet" href="./page.css">
   </head>
   <body class="evolther-2-page">
@@ -19,11 +19,28 @@
     <div class="page-shell site-shell">
       <header class="site-header">
         <nav class="site-nav" aria-label="Primary">
-          <a class="brand nav-brand" href="../" aria-label="Göther Labs home">
-            <img src="../assets/gother-mark.svg" alt="" class="brand-image">
+          <a class="brand nav-brand nav-home-wordmark animated-symbol-scope" href="../" aria-label="Göther Labs home">
+            <span aria-hidden="true" class="wordmark-mark-wrap">
+              <svg class="animated-reference-geometry live-symbol-svg" viewBox="0 0 64 64" focusable="false">
+                <g class="source-geometry" aria-hidden="true">
+                  <circle class="source-geometry-dot" cx="34.5" cy="34.5" r="3.6" />
+                  <circle class="source-geometry-dot" cx="21" cy="58" r="3.6" />
+                  <circle class="source-geometry-dot" cx="48" cy="58" r="3.6" />
+                </g>
+                <path class="live-trail" d="" />
+                <path class="live-trail" d="" />
+                <path class="live-trail" d="" />
+                <circle class="geometry-dot live-geometry-dot" cx="34.2" cy="28.4" r="3.34" />
+                <circle class="geometry-dot live-geometry-dot" cx="20.9" cy="50.6" r="3.34" />
+                <circle class="geometry-dot live-geometry-dot" cx="47.5" cy="50.6" r="3.34" />
+              </svg>
+            </span>
+            <span class="nav-wordmark-text">Göther Labs</span>
           </a>
-          <a href="../company/">Company</a>
-          <a href="../contact/">Contact</a>
+          <div class="nav-links">
+            <a href="../company/">Company</a>
+            <a href="../contact/">Contact</a>
+          </div>
         </nav>
       </header>
 
@@ -213,7 +230,7 @@
       </footer>
     </div>
 
-    <script src="../scripts.js"></script>
+    <script src="../scripts.js?v=nav-wordmark-v1"></script>
     <script src="./page.js"></script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
     <meta name="twitter:image" content="https://www.gotherlabs.com/assets/og-image.png">
     <link rel="preload" href="/assets/fonts/inter-latin.woff2" as="font" type="font/woff2" crossorigin>
     <link rel="icon" href="./assets/gother-mark.svg" type="image/svg+xml">
-    <link rel="stylesheet" href="./styles.css?v=site-gutters-v1">
+    <link rel="stylesheet" href="./styles.css?v=nav-wordmark-v1">
   </head>
   <body class="home-page">
     <a class="skip-link" href="#site-main">Skip to content</a>
@@ -70,6 +70,6 @@
 
     </div>
 
-    <script src="./scripts.js?v=results-v2"></script>
+    <script src="./scripts.js?v=nav-wordmark-v1"></script>
   </body>
 </html>

--- a/results/index.html
+++ b/results/index.html
@@ -15,7 +15,7 @@
     <meta name="twitter:image" content="https://www.gotherlabs.com/assets/og-image.png">
     <link rel="preload" href="/assets/fonts/inter-latin.woff2" as="font" type="font/woff2" crossorigin>
     <link rel="icon" href="../assets/gother-mark.svg" type="image/svg+xml">
-    <link rel="stylesheet" href="../styles.css?v=results-card-v20">
+    <link rel="stylesheet" href="../styles.css?v=nav-wordmark-v1">
 
   </head>
   <body>
@@ -23,12 +23,29 @@
     <div class="page-shell site-shell">
       <header class="site-header">
         <nav class="site-nav" aria-label="Primary">
-          <a class="brand nav-brand" href="../" aria-label="Göther Labs home">
-            <img src="../assets/gother-mark.svg" alt="" class="brand-image">
+          <a class="brand nav-brand nav-home-wordmark animated-symbol-scope" href="../" aria-label="Göther Labs home">
+            <span aria-hidden="true" class="wordmark-mark-wrap">
+              <svg class="animated-reference-geometry live-symbol-svg" viewBox="0 0 64 64" focusable="false">
+                <g class="source-geometry" aria-hidden="true">
+                  <circle class="source-geometry-dot" cx="34.5" cy="34.5" r="3.6" />
+                  <circle class="source-geometry-dot" cx="21" cy="58" r="3.6" />
+                  <circle class="source-geometry-dot" cx="48" cy="58" r="3.6" />
+                </g>
+                <path class="live-trail" d="" />
+                <path class="live-trail" d="" />
+                <path class="live-trail" d="" />
+                <circle class="geometry-dot live-geometry-dot" cx="34.2" cy="28.4" r="3.34" />
+                <circle class="geometry-dot live-geometry-dot" cx="20.9" cy="50.6" r="3.34" />
+                <circle class="geometry-dot live-geometry-dot" cx="47.5" cy="50.6" r="3.34" />
+              </svg>
+            </span>
+            <span class="nav-wordmark-text">Göther Labs</span>
           </a>
-          <a href="../company/">Company</a>
-          <a href="../results/">Results</a>
-          <a href="../contact/">Contact</a>
+          <div class="nav-links">
+            <a href="../company/">Company</a>
+            <a href="../results/">Results</a>
+            <a href="../contact/">Contact</a>
+          </div>
         </nav>
       </header>
 
@@ -165,6 +182,6 @@
       </footer>
     </div>
 
-    <script src="../scripts.js"></script>
+    <script src="../scripts.js?v=nav-wordmark-v1"></script>
   </body>
 </html>

--- a/results/quadrature-rule-optimization/index.html
+++ b/results/quadrature-rule-optimization/index.html
@@ -15,7 +15,7 @@
     <meta name="twitter:image" content="https://www.gotherlabs.com/assets/og-image.png">
     <link rel="preload" href="/assets/fonts/inter-latin.woff2" as="font" type="font/woff2" crossorigin>
     <link rel="icon" href="../../assets/gother-mark.svg" type="image/svg+xml">
-    <link rel="stylesheet" href="../../styles.css?v=results-card-v20">
+    <link rel="stylesheet" href="../../styles.css?v=nav-wordmark-v1">
     <script>
       window.MathJax = {
         tex: {
@@ -38,12 +38,29 @@
     <div class="page-shell site-shell">
       <header class="site-header">
         <nav class="site-nav" aria-label="Primary">
-          <a class="brand nav-brand" href="../../" aria-label="Göther Labs home">
-            <img src="../../assets/gother-mark.svg" alt="" class="brand-image">
+          <a class="brand nav-brand nav-home-wordmark animated-symbol-scope" href="../../" aria-label="Göther Labs home">
+            <span aria-hidden="true" class="wordmark-mark-wrap">
+              <svg class="animated-reference-geometry live-symbol-svg" viewBox="0 0 64 64" focusable="false">
+                <g class="source-geometry" aria-hidden="true">
+                  <circle class="source-geometry-dot" cx="34.5" cy="34.5" r="3.6" />
+                  <circle class="source-geometry-dot" cx="21" cy="58" r="3.6" />
+                  <circle class="source-geometry-dot" cx="48" cy="58" r="3.6" />
+                </g>
+                <path class="live-trail" d="" />
+                <path class="live-trail" d="" />
+                <path class="live-trail" d="" />
+                <circle class="geometry-dot live-geometry-dot" cx="34.2" cy="28.4" r="3.34" />
+                <circle class="geometry-dot live-geometry-dot" cx="20.9" cy="50.6" r="3.34" />
+                <circle class="geometry-dot live-geometry-dot" cx="47.5" cy="50.6" r="3.34" />
+              </svg>
+            </span>
+            <span class="nav-wordmark-text">Göther Labs</span>
           </a>
-          <a href="../../company/">Company</a>
-          <a href="../../results/">Results</a>
-          <a href="../../contact/">Contact</a>
+          <div class="nav-links">
+            <a href="../../company/">Company</a>
+            <a href="../../results/">Results</a>
+            <a href="../../contact/">Contact</a>
+          </div>
         </nav>
       </header>
 
@@ -862,6 +879,6 @@ p=1.7.
       </footer>
     </div>
 
-    <script src="../../scripts.js"></script>
+    <script src="../../scripts.js?v=nav-wordmark-v1"></script>
   </body>
 </html>

--- a/results/quadrature-rule-optimization/run/index.html
+++ b/results/quadrature-rule-optimization/run/index.html
@@ -11,19 +11,36 @@
     <meta name="robots" content="noindex, nofollow">
     <link rel="preload" href="/assets/fonts/inter-latin.woff2" as="font" type="font/woff2" crossorigin>
     <link rel="icon" href="../../../assets/gother-mark.svg" type="image/svg+xml">
-    <link rel="stylesheet" href="../../../styles.css?v=results-card-v3">
+    <link rel="stylesheet" href="../../../styles.css?v=nav-wordmark-v1">
     <link rel="stylesheet" href="./surface.css?v=quadrature-trace-v23">
   </head>
   <body class="quadrature-surface-page">
     <div class="page-shell site-shell">
       <header class="site-header">
         <nav class="site-nav" aria-label="Primary">
-          <a class="brand nav-brand" href="../../../" aria-label="Göther Labs home">
-            <img src="../../../assets/gother-mark.svg" alt="" class="brand-image">
+          <a class="brand nav-brand nav-home-wordmark animated-symbol-scope" href="../../../" aria-label="Göther Labs home">
+            <span aria-hidden="true" class="wordmark-mark-wrap">
+              <svg class="animated-reference-geometry live-symbol-svg" viewBox="0 0 64 64" focusable="false">
+                <g class="source-geometry" aria-hidden="true">
+                  <circle class="source-geometry-dot" cx="34.5" cy="34.5" r="3.6" />
+                  <circle class="source-geometry-dot" cx="21" cy="58" r="3.6" />
+                  <circle class="source-geometry-dot" cx="48" cy="58" r="3.6" />
+                </g>
+                <path class="live-trail" d="" />
+                <path class="live-trail" d="" />
+                <path class="live-trail" d="" />
+                <circle class="geometry-dot live-geometry-dot" cx="34.2" cy="28.4" r="3.34" />
+                <circle class="geometry-dot live-geometry-dot" cx="20.9" cy="50.6" r="3.34" />
+                <circle class="geometry-dot live-geometry-dot" cx="47.5" cy="50.6" r="3.34" />
+              </svg>
+            </span>
+            <span class="nav-wordmark-text">Göther Labs</span>
           </a>
-          <a href="../../../company/">Company</a>
-          <a href="../../../results/">Results</a>
-          <a href="../../../contact/">Contact</a>
+          <div class="nav-links">
+            <a href="../../../company/">Company</a>
+            <a href="../../../results/">Results</a>
+            <a href="../../../contact/">Contact</a>
+          </div>
         </nav>
       </header>
 
@@ -125,7 +142,7 @@
       </footer>
     </div>
 
-    <script src="../../../scripts.js"></script>
+    <script src="../../../scripts.js?v=nav-wordmark-v1"></script>
     <script src="./surface-data.js"></script>
     <script src="./surface.js?v=quadrature-trace-v23"></script>
   </body>

--- a/results/rcpsp-psplib-j30/index.html
+++ b/results/rcpsp-psplib-j30/index.html
@@ -15,7 +15,7 @@
     <meta name="twitter:image" content="https://www.gotherlabs.com/assets/og-image.png">
     <link rel="preload" href="/assets/fonts/inter-latin.woff2" as="font" type="font/woff2" crossorigin>
     <link rel="icon" href="../../assets/gother-mark.svg" type="image/svg+xml">
-    <link rel="stylesheet" href="../../styles.css?v=results-card-v20">
+    <link rel="stylesheet" href="../../styles.css?v=nav-wordmark-v1">
     <script>
       window.MathJax = {
         tex: {
@@ -38,12 +38,29 @@
     <div class="page-shell site-shell">
       <header class="site-header">
         <nav class="site-nav" aria-label="Primary">
-          <a class="brand nav-brand" href="../../" aria-label="Göther Labs home">
-            <img src="../../assets/gother-mark.svg" alt="" class="brand-image">
+          <a class="brand nav-brand nav-home-wordmark animated-symbol-scope" href="../../" aria-label="Göther Labs home">
+            <span aria-hidden="true" class="wordmark-mark-wrap">
+              <svg class="animated-reference-geometry live-symbol-svg" viewBox="0 0 64 64" focusable="false">
+                <g class="source-geometry" aria-hidden="true">
+                  <circle class="source-geometry-dot" cx="34.5" cy="34.5" r="3.6" />
+                  <circle class="source-geometry-dot" cx="21" cy="58" r="3.6" />
+                  <circle class="source-geometry-dot" cx="48" cy="58" r="3.6" />
+                </g>
+                <path class="live-trail" d="" />
+                <path class="live-trail" d="" />
+                <path class="live-trail" d="" />
+                <circle class="geometry-dot live-geometry-dot" cx="34.2" cy="28.4" r="3.34" />
+                <circle class="geometry-dot live-geometry-dot" cx="20.9" cy="50.6" r="3.34" />
+                <circle class="geometry-dot live-geometry-dot" cx="47.5" cy="50.6" r="3.34" />
+              </svg>
+            </span>
+            <span class="nav-wordmark-text">Göther Labs</span>
           </a>
-          <a href="../../company/">Company</a>
-          <a href="../../results/">Results</a>
-          <a href="../../contact/">Contact</a>
+          <div class="nav-links">
+            <a href="../../company/">Company</a>
+            <a href="../../results/">Results</a>
+            <a href="../../contact/">Contact</a>
+          </div>
         </nav>
       </header>
 
@@ -1072,6 +1089,6 @@ score = mean(g_k) + 0.35 \cdot p95(g_k) + feasibility\_penalty.
       </footer>
     </div>
 
-    <script src="../../scripts.js"></script>
+    <script src="../../scripts.js?v=nav-wordmark-v1"></script>
   </body>
 </html>

--- a/results/rcpsp-psplib-j30/run/index.html
+++ b/results/rcpsp-psplib-j30/run/index.html
@@ -8,19 +8,36 @@
     <meta name="robots" content="noindex, nofollow">
     <link rel="preload" href="/assets/fonts/inter-latin.woff2" as="font" type="font/woff2" crossorigin>
     <link rel="icon" href="../../../assets/gother-mark.svg" type="image/svg+xml">
-    <link rel="stylesheet" href="../../../styles.css?v=results-card-v5">
+    <link rel="stylesheet" href="../../../styles.css?v=nav-wordmark-v1">
     <link rel="stylesheet" href="./surface.css?v=rcpsp-v44">
   </head>
   <body class="rcpsp-surface-page">
     <div class="page-shell site-shell">
       <header class="site-header">
         <nav class="site-nav" aria-label="Primary">
-          <a class="brand nav-brand" href="../../../" aria-label="Göther Labs home">
-            <img src="../../../assets/gother-mark.svg" alt="" class="brand-image">
+          <a class="brand nav-brand nav-home-wordmark animated-symbol-scope" href="../../../" aria-label="Göther Labs home">
+            <span aria-hidden="true" class="wordmark-mark-wrap">
+              <svg class="animated-reference-geometry live-symbol-svg" viewBox="0 0 64 64" focusable="false">
+                <g class="source-geometry" aria-hidden="true">
+                  <circle class="source-geometry-dot" cx="34.5" cy="34.5" r="3.6" />
+                  <circle class="source-geometry-dot" cx="21" cy="58" r="3.6" />
+                  <circle class="source-geometry-dot" cx="48" cy="58" r="3.6" />
+                </g>
+                <path class="live-trail" d="" />
+                <path class="live-trail" d="" />
+                <path class="live-trail" d="" />
+                <circle class="geometry-dot live-geometry-dot" cx="34.2" cy="28.4" r="3.34" />
+                <circle class="geometry-dot live-geometry-dot" cx="20.9" cy="50.6" r="3.34" />
+                <circle class="geometry-dot live-geometry-dot" cx="47.5" cy="50.6" r="3.34" />
+              </svg>
+            </span>
+            <span class="nav-wordmark-text">Göther Labs</span>
           </a>
-          <a href="../../../company/">Company</a>
-          <a href="../../../results/">Results</a>
-          <a href="../../../contact/">Contact</a>
+          <div class="nav-links">
+            <a href="../../../company/">Company</a>
+            <a href="../../../results/">Results</a>
+            <a href="../../../contact/">Contact</a>
+          </div>
         </nav>
       </header>
 
@@ -123,7 +140,7 @@
       </footer>
     </div>
 
-    <script src="../../../scripts.js"></script>
+    <script src="../../../scripts.js?v=nav-wordmark-v1"></script>
     <script src="./surface-data.js"></script>
     <script src="./surface.js?v=rcpsp-v44"></script>
   </body>

--- a/scripts.js
+++ b/scripts.js
@@ -4,13 +4,13 @@ if (yearNode) {
   yearNode.textContent = new Date().getFullYear().toString();
 }
 
-const animatedSymbolPage =
-  document.body.classList.contains("home-page") ||
-  document.body.classList.contains("not-found-page");
+const animatedSymbolScopes = Array.from(document.querySelectorAll(".animated-symbol-scope"));
 const reducedMotionQuery = window.matchMedia("(prefers-reduced-motion: reduce)");
 
-if (animatedSymbolPage && !reducedMotionQuery.matches) {
-  initializeThreeBodySystem();
+if (animatedSymbolScopes.length > 0 && !reducedMotionQuery.matches) {
+  animatedSymbolScopes.forEach((symbolScope) => {
+    initializeThreeBodySystem(symbolScope);
+  });
 }
 
 initializeEvolutionDemo();
@@ -469,8 +469,7 @@ function initializeEvolutionDemo() {
   }
 }
 
-function initializeThreeBodySystem() {
-  const symbolScope = document.querySelector(".animated-symbol-scope");
+function initializeThreeBodySystem(symbolScope) {
   const referenceGeometry = symbolScope?.querySelector(".animated-reference-geometry");
   const bodyNodes = Array.from(
     symbolScope?.querySelectorAll(".live-geometry-dot") || []
@@ -497,6 +496,9 @@ function initializeThreeBodySystem() {
   const historyLength = 240;
   const gravityStrength = 2200;
   const softening = 12;
+  const storageKey = "gother-logo-animation-state-v1";
+  const maxRestoreAgeMs = 8000;
+  const maxCatchUpMs = 1600;
   let state = null;
   let history = [];
   let accumulator = 0;
@@ -505,6 +507,7 @@ function initializeThreeBodySystem() {
   let gravityActive = false;
   let phase = "idle";
   let phaseStartTime = performance.now();
+  let phaseWallStartTime = Date.now();
   let collapseSourceState = null;
   let collapseReferenceState = null;
   let referenceState = null;
@@ -513,13 +516,21 @@ function initializeThreeBodySystem() {
   let collapseTimeoutId = 0;
   let resetTimeoutId = 0;
 
-  resetToReference();
-  scheduleWakeSequence();
+  if (!restorePersistedAnimation()) {
+    resetToReference();
+    scheduleWakeSequence();
+  }
 
   window.addEventListener("resize", handleViewportChange);
   if (window.visualViewport) {
     window.visualViewport.addEventListener("resize", handleViewportChange);
   }
+  window.addEventListener("pagehide", persistAnimationState);
+  document.addEventListener("visibilitychange", () => {
+    if (document.visibilityState === "hidden") {
+      persistAnimationState();
+    }
+  });
   requestAnimationFrame(frame);
 
   function frame(now) {
@@ -589,6 +600,7 @@ function initializeThreeBodySystem() {
     isAwake = false;
     gravityActive = false;
     phase = "idle";
+    markPhaseStart();
     collapseSourceState = null;
     collapseReferenceState = null;
     referenceState = null;
@@ -598,34 +610,6 @@ function initializeThreeBodySystem() {
     syncBodyNodes(bodyNodes, previewState.positions, previewState.radii);
     drawTrails(trailNodes, []);
     render(0);
-  }
-
-  function scheduleWakeSequence() {
-    wakeTimeoutId = window.setTimeout(() => {
-      if (!state) {
-        state = createStateFromReferenceGlyph(referenceGeometry);
-      }
-      referenceState = cloneSystemState(state);
-      history = state.positions.map((position) => [copyVector(position)]);
-      phase = "settling";
-      phaseStartTime = performance.now();
-      syncBodyNodes(bodyNodes, state.positions, state.radii);
-      isAwake = true;
-      render(1);
-      requestAnimationFrame(() => {
-        document.body.classList.add("logo-awake");
-      });
-      gravityTimeoutId = window.setTimeout(() => {
-        applyWakePerturbation(state);
-        gravityActive = true;
-        phase = "gravity";
-        phaseStartTime = performance.now();
-        document.body.classList.add("gravity-live");
-        collapseTimeoutId = window.setTimeout(() => {
-          beginCollapse();
-        }, activeDurationMs);
-      }, settleDelayMs);
-    }, wakeDelayMs);
   }
 
   function handleViewportChange() {
@@ -668,7 +652,7 @@ function initializeThreeBodySystem() {
     gravityActive = false;
     accumulator = 0;
     phase = "collapsing";
-    phaseStartTime = performance.now();
+    markPhaseStart();
     collapseSourceState = {
       positions: state.positions.map(copyVector),
       radii: state.radii.slice(),
@@ -680,6 +664,216 @@ function initializeThreeBodySystem() {
       resetToReference();
       scheduleWakeSequence();
     }, collapseDurationMs + resetDelayMs);
+  }
+
+  function enterGravity(catchUpMs = 0) {
+    if (!state) {
+      return;
+    }
+
+    applyWakePerturbation(state);
+    gravityActive = true;
+    phase = "gravity";
+    markPhaseStart(catchUpMs);
+    document.body.classList.add("gravity-live");
+
+    if (catchUpMs > 0) {
+      advanceGravityBy(Math.min(catchUpMs, maxCatchUpMs));
+    }
+
+    const remainingActiveMs = Math.max(activeDurationMs - catchUpMs, 0);
+    collapseTimeoutId = window.setTimeout(() => {
+      beginCollapse();
+    }, remainingActiveMs);
+  }
+
+  function markPhaseStart(elapsedMs = 0) {
+    phaseStartTime = performance.now() - elapsedMs;
+    phaseWallStartTime = Date.now() - elapsedMs;
+  }
+
+  function persistAnimationState() {
+    if (!window.sessionStorage || !state) {
+      return;
+    }
+
+    try {
+      window.sessionStorage.setItem(
+        storageKey,
+        JSON.stringify({
+          savedAt: Date.now(),
+          phase,
+          phaseElapsedMs: Math.max(0, Date.now() - phaseWallStartTime),
+          isAwake,
+          gravityActive,
+          state,
+          history,
+          accumulator,
+          referenceState,
+          collapseSourceState,
+          collapseReferenceState,
+        })
+      );
+    } catch (error) {
+      // Storage can be unavailable in private contexts; the logo can safely restart.
+    }
+  }
+
+  function restorePersistedAnimation() {
+    const persistedState = readPersistedAnimationState();
+
+    if (!persistedState) {
+      return false;
+    }
+
+    window.clearTimeout(wakeTimeoutId);
+    window.clearTimeout(gravityTimeoutId);
+    window.clearTimeout(collapseTimeoutId);
+    window.clearTimeout(resetTimeoutId);
+
+    state = hydrateSystemState(persistedState.state);
+
+    if (!state) {
+      return false;
+    }
+
+    history = hydrateHistory(persistedState.history);
+    accumulator = Number.isFinite(persistedState.accumulator) ? persistedState.accumulator : 0;
+    isAwake = Boolean(persistedState.isAwake);
+    gravityActive = Boolean(persistedState.gravityActive);
+    phase = typeof persistedState.phase === "string" ? persistedState.phase : "idle";
+    referenceState = hydrateSystemState(persistedState.referenceState) || createStateFromReferenceGlyph(referenceGeometry);
+    collapseSourceState = hydrateCollapseState(persistedState.collapseSourceState);
+    collapseReferenceState = hydrateSystemState(persistedState.collapseReferenceState);
+
+    const savedAgeMs = Math.max(0, Date.now() - persistedState.savedAt);
+    const phaseElapsedMs = Math.max(0, (persistedState.phaseElapsedMs || 0) + savedAgeMs);
+    markPhaseStart(phaseElapsedMs);
+    lastFrameTime = performance.now();
+
+    if (isAwake) {
+      document.body.classList.add("logo-awake");
+    }
+
+    if (phase === "idle") {
+      resetToReference();
+      scheduleWakeSequence(Math.max(wakeDelayMs - phaseElapsedMs, 0));
+      return true;
+    }
+
+    if (phase === "settling") {
+      document.body.classList.remove("gravity-live");
+      syncBodyNodes(bodyNodes, state.positions, state.radii);
+      drawTrails(trailNodes, history);
+      render(1);
+
+      if (phaseElapsedMs >= settleDelayMs) {
+        enterGravity(phaseElapsedMs - settleDelayMs);
+      } else {
+        gravityTimeoutId = window.setTimeout(() => {
+          enterGravity(0);
+        }, settleDelayMs - phaseElapsedMs);
+      }
+
+      return true;
+    }
+
+    if (phase === "gravity") {
+      gravityActive = true;
+      document.body.classList.add("gravity-live");
+      advanceGravityBy(Math.min(savedAgeMs, maxCatchUpMs));
+      syncBodyNodes(bodyNodes, state.positions, state.radii);
+      drawTrails(trailNodes, history);
+      render(1);
+      collapseTimeoutId = window.setTimeout(() => {
+        beginCollapse();
+      }, Math.max(activeDurationMs - phaseElapsedMs, 0));
+      return true;
+    }
+
+    if (phase === "collapsing" && collapseSourceState && collapseReferenceState) {
+      gravityActive = false;
+      document.body.classList.remove("gravity-live");
+
+      if (phaseElapsedMs >= collapseDurationMs + resetDelayMs) {
+        resetToReference();
+        scheduleWakeSequence();
+        return true;
+      }
+
+      syncBodyNodes(bodyNodes, state.positions, state.radii);
+      drawTrails(trailNodes, history);
+      render(1);
+      resetTimeoutId = window.setTimeout(() => {
+        resetToReference();
+        scheduleWakeSequence();
+      }, Math.max(collapseDurationMs + resetDelayMs - phaseElapsedMs, 0));
+      return true;
+    }
+
+    return false;
+  }
+
+  function scheduleWakeSequence(delayMs = wakeDelayMs) {
+    wakeTimeoutId = window.setTimeout(() => {
+      if (!state) {
+        state = createStateFromReferenceGlyph(referenceGeometry);
+      }
+      referenceState = cloneSystemState(state);
+      history = state.positions.map((position) => [copyVector(position)]);
+      phase = "settling";
+      markPhaseStart();
+      syncBodyNodes(bodyNodes, state.positions, state.radii);
+      isAwake = true;
+      render(1);
+      requestAnimationFrame(() => {
+        document.body.classList.add("logo-awake");
+      });
+      gravityTimeoutId = window.setTimeout(() => {
+        enterGravity(0);
+      }, settleDelayMs);
+    }, delayMs);
+  }
+
+  function advanceGravityBy(milliseconds) {
+    if (!state || milliseconds <= 0) {
+      return;
+    }
+
+    let remainingSeconds = milliseconds / 1000;
+
+    while (remainingSeconds >= integratorStep) {
+      stepThreeBodyState(state, integratorStep, gravityStrength, softening);
+      recordHistory(history, state.positions, historyLength);
+      remainingSeconds -= integratorStep;
+    }
+
+    accumulator = Math.max(0, remainingSeconds);
+  }
+
+  function readPersistedAnimationState() {
+    if (!window.sessionStorage) {
+      return null;
+    }
+
+    try {
+      const rawState = window.sessionStorage.getItem(storageKey);
+
+      if (!rawState) {
+        return null;
+      }
+
+      const parsedState = JSON.parse(rawState);
+      const savedAgeMs = Date.now() - parsedState.savedAt;
+
+      if (!Number.isFinite(savedAgeMs) || savedAgeMs > maxRestoreAgeMs) {
+        return null;
+      }
+
+      return parsedState;
+    } catch (error) {
+      return null;
+    }
   }
 }
 
@@ -827,6 +1021,84 @@ function cloneSystemState(systemState) {
     positions: systemState.positions.map(copyVector),
     radii: systemState.radii.slice(),
   };
+}
+
+function hydrateSystemState(systemState) {
+  if (!systemState || !Array.isArray(systemState.positions) || !Array.isArray(systemState.radii)) {
+    return null;
+  }
+
+  const positions = systemState.positions.map(hydrateVector);
+
+  if (positions.some((position) => !position)) {
+    return null;
+  }
+
+  const radii = systemState.radii.map((radius) => Number(radius));
+
+  if (radii.length !== positions.length || radii.some((radius) => !Number.isFinite(radius))) {
+    return null;
+  }
+
+  const velocities = Array.isArray(systemState.velocities)
+    ? systemState.velocities.map(hydrateVector)
+    : positions.map(() => ({ x: 0, y: 0 }));
+  const masses = Array.isArray(systemState.masses)
+    ? systemState.masses.map((mass) => Number(mass))
+    : positions.map(() => 1);
+
+  return {
+    positions,
+    velocities: velocities.length !== positions.length || velocities.some((velocity) => !velocity)
+      ? positions.map(() => ({ x: 0, y: 0 }))
+      : velocities,
+    masses: masses.length !== positions.length || masses.some((mass) => !Number.isFinite(mass))
+      ? positions.map(() => 1)
+      : masses,
+    radii,
+  };
+}
+
+function hydrateCollapseState(collapseState) {
+  const hydratedState = hydrateSystemState(collapseState);
+
+  if (!hydratedState) {
+    return null;
+  }
+
+  return {
+    positions: hydratedState.positions,
+    radii: hydratedState.radii,
+  };
+}
+
+function hydrateHistory(history) {
+  if (!Array.isArray(history)) {
+    return [];
+  }
+
+  return history.map((trail) => {
+    if (!Array.isArray(trail)) {
+      return [];
+    }
+
+    return trail.map(hydrateVector).filter(Boolean);
+  });
+}
+
+function hydrateVector(vector) {
+  if (!vector) {
+    return null;
+  }
+
+  const x = Number(vector.x);
+  const y = Number(vector.y);
+
+  if (!Number.isFinite(x) || !Number.isFinite(y)) {
+    return null;
+  }
+
+  return { x, y };
 }
 
 function createReferenceTransform(previousReferenceState, nextReferenceState) {

--- a/styles.css
+++ b/styles.css
@@ -973,7 +973,7 @@ a {
 
 .result-card--rcpsp .result-card-visual {
   color: var(--accent);
-  transform: translateY(-1.2rem);
+  transform: translateY(-2.6rem);
 }
 
 .result-card-rcpsp line,
@@ -2932,7 +2932,7 @@ a {
 
   .result-card--rcpsp .result-card-visual {
     display: block;
-    transform: translateY(-0.75rem);
+    transform: translateY(-1.6rem);
   }
 
   .result-measure {

--- a/styles.css
+++ b/styles.css
@@ -1070,10 +1070,16 @@ a {
     border-bottom: 0;
   }
 
+  .result-card-visual {
+    right: -6.8rem;
+    bottom: -0.75rem;
+    width: min(56%, 34rem);
+    -webkit-mask-image: linear-gradient(90deg, transparent 0 18%, rgba(0, 0, 0, 0.16) 34%, #000 52%);
+    mask-image: linear-gradient(90deg, transparent 0 18%, rgba(0, 0, 0, 0.16) 34%, #000 52%);
+  }
+
   .result-card--rcpsp .result-card-visual {
-    right: clamp(-8rem, -5vw, -2.5rem);
-    bottom: clamp(5.6rem, 8vw, 8.2rem);
-    width: min(62%, 38rem);
+    transform: translateY(-2.4rem);
   }
 }
 
@@ -2922,17 +2928,17 @@ a {
   }
 
   .result-card-visual {
-    right: -6.6rem;
-    bottom: -0.5rem;
-    width: 82%;
+    right: -4.8rem;
+    bottom: -1rem;
+    width: 78%;
     opacity: 1;
-    -webkit-mask-image: linear-gradient(90deg, transparent 0 24%, rgba(0, 0, 0, 0.16) 42%, #000 60%);
-    mask-image: linear-gradient(90deg, transparent 0 24%, rgba(0, 0, 0, 0.16) 42%, #000 60%);
+    -webkit-mask-image: linear-gradient(90deg, transparent 0 22%, rgba(0, 0, 0, 0.16) 40%, #000 58%);
+    mask-image: linear-gradient(90deg, transparent 0 22%, rgba(0, 0, 0, 0.16) 40%, #000 58%);
   }
 
   .result-card--rcpsp .result-card-visual {
     display: block;
-    transform: translateY(-1.6rem);
+    transform: translateY(-1.55rem);
   }
 
   .result-measure {

--- a/styles.css
+++ b/styles.css
@@ -912,15 +912,15 @@ a {
 
 .result-card-visual {
   position: absolute;
-  right: clamp(-11rem, -7.5vw, -4rem);
+  right: clamp(-8rem, -5.5vw, -2.5rem);
   bottom: clamp(-0.9rem, -1.2vw, -0.15rem);
   z-index: 0;
-  width: min(62%, 37rem);
+  width: min(68%, 40rem);
   height: auto;
   color: var(--accent);
   opacity: 1;
-  -webkit-mask-image: linear-gradient(90deg, transparent 0 24%, rgba(0, 0, 0, 0.16) 40%, #000 58%);
-  mask-image: linear-gradient(90deg, transparent 0 24%, rgba(0, 0, 0, 0.16) 40%, #000 58%);
+  -webkit-mask-image: linear-gradient(90deg, transparent 0 16%, rgba(0, 0, 0, 0.16) 32%, #000 50%);
+  mask-image: linear-gradient(90deg, transparent 0 16%, rgba(0, 0, 0, 0.16) 32%, #000 50%);
   pointer-events: none;
 }
 

--- a/styles.css
+++ b/styles.css
@@ -912,15 +912,15 @@ a {
 
 .result-card-visual {
   position: absolute;
-  right: clamp(-12rem, -8vw, -4rem);
+  right: clamp(-10rem, -7vw, -3.5rem);
   bottom: clamp(1.4rem, 3.2vw, 3.8rem);
   z-index: 0;
   width: min(58%, 35rem);
   height: auto;
   color: var(--accent);
-  opacity: 0.3;
-  -webkit-mask-image: linear-gradient(135deg, transparent 0 18%, rgba(0, 0, 0, 0.18) 42%, #000 68%);
-  mask-image: linear-gradient(135deg, transparent 0 18%, rgba(0, 0, 0, 0.18) 42%, #000 68%);
+  opacity: 0.36;
+  -webkit-mask-image: linear-gradient(90deg, transparent 0 18%, rgba(0, 0, 0, 0.22) 34%, #000 56%);
+  mask-image: linear-gradient(90deg, transparent 0 18%, rgba(0, 0, 0, 0.22) 34%, #000 56%);
   pointer-events: none;
 }
 
@@ -972,11 +972,11 @@ a {
 }
 
 .result-card--rcpsp .result-card-visual {
-  right: clamp(-12rem, -8vw, -4rem);
+  right: clamp(-10rem, -7vw, -3.5rem);
   bottom: clamp(1.4rem, 3.2vw, 3.8rem);
   width: min(58%, 35rem);
   color: var(--accent);
-  opacity: 0.3;
+  opacity: 0.36;
 }
 
 .result-card-rcpsp line,
@@ -2925,20 +2925,20 @@ a {
   }
 
   .result-card-visual {
-    right: -8.5rem;
-    bottom: 1.5rem;
-    width: 76%;
-    opacity: 0.2;
-    -webkit-mask-image: linear-gradient(135deg, transparent 0 24%, rgba(0, 0, 0, 0.14) 52%, #000 76%);
-    mask-image: linear-gradient(135deg, transparent 0 24%, rgba(0, 0, 0, 0.14) 52%, #000 76%);
+    right: -5rem;
+    bottom: 1.4rem;
+    width: 78%;
+    opacity: 0.28;
+    -webkit-mask-image: linear-gradient(90deg, transparent 0 20%, rgba(0, 0, 0, 0.24) 36%, #000 54%);
+    mask-image: linear-gradient(90deg, transparent 0 20%, rgba(0, 0, 0, 0.24) 36%, #000 54%);
   }
 
   .result-card--rcpsp .result-card-visual {
     display: block;
-    right: -8.5rem;
-    bottom: 1.5rem;
-    width: 72%;
-    opacity: 0.2;
+    right: -5rem;
+    bottom: 1.4rem;
+    width: 74%;
+    opacity: 0.28;
   }
 
   .result-measure {

--- a/styles.css
+++ b/styles.css
@@ -912,14 +912,15 @@ a {
 
 .result-card-visual {
   position: absolute;
-  right: clamp(-10rem, -7vw, -3.5rem);
-  bottom: clamp(-1.2rem, -1.5vw, -0.2rem);
+  right: clamp(-11rem, -7.5vw, -4rem);
+  bottom: clamp(-0.9rem, -1.2vw, -0.15rem);
   z-index: 0;
   width: min(62%, 37rem);
   height: auto;
   color: var(--accent);
   opacity: 1;
-  clip-path: inset(0 0 0 22%);
+  -webkit-mask-image: linear-gradient(90deg, transparent 0 24%, rgba(0, 0, 0, 0.16) 40%, #000 58%);
+  mask-image: linear-gradient(90deg, transparent 0 24%, rgba(0, 0, 0, 0.16) 40%, #000 58%);
   pointer-events: none;
 }
 
@@ -971,11 +972,7 @@ a {
 }
 
 .result-card--rcpsp .result-card-visual {
-  right: clamp(-10rem, -7vw, -3.5rem);
-  bottom: clamp(-1.2rem, -1.5vw, -0.2rem);
-  width: min(62%, 37rem);
   color: var(--accent);
-  opacity: 1;
 }
 
 .result-card-rcpsp line,
@@ -2924,19 +2921,16 @@ a {
   }
 
   .result-card-visual {
-    right: -6.5rem;
-    bottom: -0.65rem;
-    width: 84%;
+    right: -6.6rem;
+    bottom: -0.5rem;
+    width: 82%;
     opacity: 1;
-    clip-path: inset(0 0 0 26%);
+    -webkit-mask-image: linear-gradient(90deg, transparent 0 24%, rgba(0, 0, 0, 0.16) 42%, #000 60%);
+    mask-image: linear-gradient(90deg, transparent 0 24%, rgba(0, 0, 0, 0.16) 42%, #000 60%);
   }
 
   .result-card--rcpsp .result-card-visual {
     display: block;
-    right: -6.5rem;
-    bottom: -0.65rem;
-    width: 80%;
-    opacity: 1;
   }
 
   .result-measure {

--- a/styles.css
+++ b/styles.css
@@ -913,14 +913,13 @@ a {
 .result-card-visual {
   position: absolute;
   right: clamp(-10rem, -7vw, -3.5rem);
-  bottom: clamp(1.4rem, 3.2vw, 3.8rem);
+  bottom: clamp(-1.2rem, -1.5vw, -0.2rem);
   z-index: 0;
-  width: min(58%, 35rem);
+  width: min(62%, 37rem);
   height: auto;
   color: var(--accent);
-  opacity: 0.36;
-  -webkit-mask-image: linear-gradient(90deg, transparent 0 18%, rgba(0, 0, 0, 0.22) 34%, #000 56%);
-  mask-image: linear-gradient(90deg, transparent 0 18%, rgba(0, 0, 0, 0.22) 34%, #000 56%);
+  opacity: 1;
+  clip-path: inset(0 0 0 22%);
   pointer-events: none;
 }
 
@@ -973,10 +972,10 @@ a {
 
 .result-card--rcpsp .result-card-visual {
   right: clamp(-10rem, -7vw, -3.5rem);
-  bottom: clamp(1.4rem, 3.2vw, 3.8rem);
-  width: min(58%, 35rem);
+  bottom: clamp(-1.2rem, -1.5vw, -0.2rem);
+  width: min(62%, 37rem);
   color: var(--accent);
-  opacity: 0.36;
+  opacity: 1;
 }
 
 .result-card-rcpsp line,
@@ -2925,20 +2924,19 @@ a {
   }
 
   .result-card-visual {
-    right: -5rem;
-    bottom: 1.4rem;
-    width: 78%;
-    opacity: 0.28;
-    -webkit-mask-image: linear-gradient(90deg, transparent 0 20%, rgba(0, 0, 0, 0.24) 36%, #000 54%);
-    mask-image: linear-gradient(90deg, transparent 0 20%, rgba(0, 0, 0, 0.24) 36%, #000 54%);
+    right: -6.5rem;
+    bottom: -0.65rem;
+    width: 84%;
+    opacity: 1;
+    clip-path: inset(0 0 0 26%);
   }
 
   .result-card--rcpsp .result-card-visual {
     display: block;
-    right: -5rem;
-    bottom: 1.4rem;
-    width: 74%;
-    opacity: 0.28;
+    right: -6.5rem;
+    bottom: -0.65rem;
+    width: 80%;
+    opacity: 1;
   }
 
   .result-measure {

--- a/styles.css
+++ b/styles.css
@@ -912,13 +912,15 @@ a {
 
 .result-card-visual {
   position: absolute;
-  right: clamp(-8rem, -5vw, -2.5rem);
-  bottom: clamp(5.6rem, 8vw, 8.2rem);
+  right: clamp(-12rem, -8vw, -4rem);
+  bottom: clamp(1.4rem, 3.2vw, 3.8rem);
   z-index: 0;
-  width: min(62%, 38rem);
+  width: min(58%, 35rem);
   height: auto;
   color: var(--accent);
-  opacity: 0.38;
+  opacity: 0.3;
+  -webkit-mask-image: linear-gradient(135deg, transparent 0 18%, rgba(0, 0, 0, 0.18) 42%, #000 68%);
+  mask-image: linear-gradient(135deg, transparent 0 18%, rgba(0, 0, 0, 0.18) 42%, #000 68%);
   pointer-events: none;
 }
 
@@ -970,11 +972,11 @@ a {
 }
 
 .result-card--rcpsp .result-card-visual {
-  right: clamp(-8rem, -5vw, -2.5rem);
-  bottom: clamp(5.6rem, 8vw, 8.2rem);
-  width: min(62%, 38rem);
+  right: clamp(-12rem, -8vw, -4rem);
+  bottom: clamp(1.4rem, 3.2vw, 3.8rem);
+  width: min(58%, 35rem);
   color: var(--accent);
-  opacity: 0.38;
+  opacity: 0.3;
 }
 
 .result-card-rcpsp line,
@@ -2923,18 +2925,20 @@ a {
   }
 
   .result-card-visual {
-    right: -7rem;
-    bottom: 5.5rem;
-    width: 72%;
-    opacity: 0.24;
+    right: -8.5rem;
+    bottom: 1.5rem;
+    width: 76%;
+    opacity: 0.2;
+    -webkit-mask-image: linear-gradient(135deg, transparent 0 24%, rgba(0, 0, 0, 0.14) 52%, #000 76%);
+    mask-image: linear-gradient(135deg, transparent 0 24%, rgba(0, 0, 0, 0.14) 52%, #000 76%);
   }
 
   .result-card--rcpsp .result-card-visual {
     display: block;
-    right: -7rem;
-    bottom: 5.5rem;
+    right: -8.5rem;
+    bottom: 1.5rem;
     width: 72%;
-    opacity: 0.24;
+    opacity: 0.2;
   }
 
   .result-measure {

--- a/styles.css
+++ b/styles.css
@@ -165,6 +165,15 @@ a {
   background: var(--bg);
 }
 
+.site-nav:has(.nav-home-wordmark) {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
+  flex: 1 1 auto;
+  width: 100%;
+  justify-content: stretch;
+  padding: 0.5rem 0;
+}
+
 .site-nav a,
 .site-footer a {
   color: var(--text);
@@ -174,6 +183,29 @@ a {
   font-size: 0.95rem;
   line-height: 1;
   letter-spacing: -0.01em;
+}
+
+.site-nav .nav-home-wordmark {
+  grid-column: 2;
+  justify-self: center;
+  gap: 0.34rem;
+  font-size: clamp(1.08rem, 1.55vw, 1.34rem);
+  font-weight: 600;
+  letter-spacing: -0.04em;
+  white-space: nowrap;
+}
+
+.site-nav .nav-home-wordmark .wordmark-mark-wrap {
+  width: 0.82em;
+  height: 0.82em;
+}
+
+.nav-links {
+  grid-column: 3;
+  justify-self: end;
+  display: flex;
+  align-items: center;
+  gap: 1rem;
 }
 
 .brand:focus-visible,
@@ -2798,6 +2830,26 @@ a {
     flex-wrap: nowrap;
     min-width: max-content;
     padding-left: 0;
+  }
+
+  .site-nav:has(.nav-home-wordmark) {
+    grid-template-columns: 1fr;
+    justify-content: center;
+    min-width: 0;
+  }
+
+  .nav-home-wordmark,
+  .nav-links {
+    grid-column: 1;
+    justify-self: center;
+  }
+
+  .site-nav .nav-home-wordmark {
+    font-size: 1.08rem;
+  }
+
+  .nav-links {
+    gap: 0.85rem;
   }
 
   .site-main {

--- a/styles.css
+++ b/styles.css
@@ -973,6 +973,7 @@ a {
 
 .result-card--rcpsp .result-card-visual {
   color: var(--accent);
+  transform: translateY(-1.2rem);
 }
 
 .result-card-rcpsp line,
@@ -2931,6 +2932,7 @@ a {
 
   .result-card--rcpsp .result-card-visual {
     display: block;
+    transform: translateY(-0.75rem);
   }
 
   .result-measure {


### PR DESCRIPTION
Why
- The results index needed a more polished visual treatment that keeps the technical artwork readable without interfering with the result card copy.
- Internal pages now use the Göther Labs animated wordmark as the centered home affordance instead of the small mark-only link.
- The animated logo should feel continuous when moving between pages, including back to the home page.

What changed
- Refined result card artwork positioning, masking, and baseline alignment across desktop and responsive layouts.
- Replaced the internal-page home mark with a centered animated Göther Labs wordmark and moved nav links into a right-side group.
- Updated all internal routes and result detail/run pages to use the new header structure.
- Extended the logo animation system to support multiple symbol scopes and persist animation state through page navigation via sessionStorage.
- Removed the temporary Evölther hyperlink from the Company page while preserving the visual emphasis.

Why this approach
- Reuses the existing home logo SVG and animation logic rather than introducing a separate brand asset.
- Keeps the home page navigation behavior unchanged while scoping the new centered header layout to pages that include the wordmark.
- Stores only transient animation state so reloads and page changes feel continuous without adding dependencies or routing infrastructure.

How to review
- Open /company/ and confirm the centered animated Göther Labs wordmark replaces the previous small mark.
- Wait for the symbol to animate, then navigate to /results/ and back to / to confirm the animation does not visibly restart.
- Check /results/ on desktop and reduced-width viewports to verify the card visuals remain aligned and readable.

Validation
- git diff --check
- node --check scripts.js
- curl -I http://127.0.0.1:4173/
- curl -I http://127.0.0.1:4173/company/
- curl -I http://127.0.0.1:4173/results/
- Browser validation: company -> results and company -> home preserve logo animation state with no console warnings/errors.

Testing
- Static site smoke checks passed locally.
- No automated test suite exists for this static site.