### PR TITLE
Fix mobile result card visual composition

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1103,15 +1103,16 @@ a {
   }
 
   .result-card-visual {
-    right: -6.8rem;
-    bottom: -0.75rem;
-    width: min(56%, 34rem);
-    -webkit-mask-image: linear-gradient(90deg, transparent 0 18%, rgba(0, 0, 0, 0.16) 34%, #000 52%);
-    mask-image: linear-gradient(90deg, transparent 0 18%, rgba(0, 0, 0, 0.16) 34%, #000 52%);
+    right: clamp(1rem, 3vw, 1.8rem);
+    bottom: clamp(0.9rem, 2.4vw, 1.5rem);
+    width: min(48%, 28rem);
+    opacity: 0.78;
+    -webkit-mask-image: linear-gradient(90deg, transparent 0 10%, rgba(0, 0, 0, 0.42) 28%, #000 48%);
+    mask-image: linear-gradient(90deg, transparent 0 10%, rgba(0, 0, 0, 0.42) 28%, #000 48%);
   }
 
   .result-card--rcpsp .result-card-visual {
-    transform: translateY(-2.4rem);
+    transform: translateY(-1.25rem);
   }
 }
 
@@ -2980,17 +2981,17 @@ a {
   }
 
   .result-card-visual {
-    right: -4.8rem;
-    bottom: -1rem;
-    width: 78%;
-    opacity: 1;
-    -webkit-mask-image: linear-gradient(90deg, transparent 0 22%, rgba(0, 0, 0, 0.16) 40%, #000 58%);
-    mask-image: linear-gradient(90deg, transparent 0 22%, rgba(0, 0, 0, 0.16) 40%, #000 58%);
+    right: 0.95rem;
+    bottom: 1rem;
+    width: min(48%, 13rem);
+    opacity: 0.72;
+    -webkit-mask-image: linear-gradient(90deg, transparent 0 8%, rgba(0, 0, 0, 0.48) 26%, #000 46%);
+    mask-image: linear-gradient(90deg, transparent 0 8%, rgba(0, 0, 0, 0.48) 26%, #000 46%);
   }
 
   .result-card--rcpsp .result-card-visual {
     display: block;
-    transform: translateY(-1.55rem);
+    transform: translateY(-0.8rem);
   }
 
   .result-measure {


### PR DESCRIPTION
## Why

Closes #33.

The results index cards used large absolutely positioned SVG visuals that were pushed outside the card on narrow viewports. The page avoided horizontal scrolling, but the composition depended on clipping and made the visuals feel accidentally cropped on mobile.

## What changed

- Contained result card SVG visuals inside the card at the `max-width: 980px` and `max-width: 720px` breakpoints.
- Reduced mobile/tablet visual size and opacity so the SVGs support the card content instead of crowding it.
- Adjusted the RCPSP visual vertical offset for the new contained composition.
- Left the desktop two-column layout unchanged.

## Why this approach

This is the smallest CSS-only fix for the issue. It keeps the existing card structure and desktop treatment, while making the responsive visual placement deliberate instead of relying on negative offsets and clipping.

## How to review

1. Open `/results/` locally.
2. Compare the result cards at 390px, 720px, and 980px.
3. Confirm the SVG visuals remain inside their cards and do not collide with title, summary, or metric text.
4. Confirm the desktop layout is unchanged.

## Validation

- `git diff --check`
- Local preview at `http://127.0.0.1:4173/results/`
- Browser DOM/console check through the in-app browser: page identity, nonblank content, no framework overlay, no warnings/errors.
- Playwright CLI screenshots and layout metrics at 390px, 720px, and 980px.

## Testing

At 390px, each result card is 351px wide. Before this change, each SVG ended at x=447, outside both the card and viewport. After this change, each SVG ends at x=355, inside the card boundary. The same containment check passes at 720px and 980px, with no horizontal scroll.
