### PR TITLE
Add local 404 fallback preview server

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,20 @@ python3 -m http.server 4173
 
 Then open `http://127.0.0.1:4173/`.
 
+To preview GitHub Pages-style custom 404 behavior for unknown routes, use the local preview helper instead:
+
+```bash
+node tools/preview.mjs
+```
+
+Then open `http://127.0.0.1:4173/domains` or another missing route. The helper serves `404.html` with a 404 status, matching the production fallback more closely than Python's built-in error page.
+
+If port `4173` is already in use, pass another port:
+
+```bash
+node tools/preview.mjs 4174
+```
+
 ## Maintenance rules
 
 - Keep tracked assets only when they are used by the site or by a documented helper workflow.

--- a/docs/site-shell.md
+++ b/docs/site-shell.md
@@ -77,6 +77,8 @@ git diff --check
 python3 -m http.server 4173
 ```
 
+Use `python3 -m http.server 4173` for the simplest static preview. Use `node tools/preview.mjs` when validating GitHub Pages-style 404 fallback behavior for unknown routes such as `/domains`; Python's built-in server shows its own error page for those routes. If port `4173` is already in use, run `node tools/preview.mjs 4174`.
+
 Then spot-check:
 
 - `/`

--- a/tools/preview.mjs
+++ b/tools/preview.mjs
@@ -1,0 +1,129 @@
+#!/usr/bin/env node
+import fs from "node:fs/promises";
+import http from "node:http";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SITE_ROOT = path.resolve(__dirname, "..");
+const DEFAULT_PORT = 4173;
+const port = Number(process.env.PORT || process.argv[2] || DEFAULT_PORT);
+
+const MIME_TYPES = new Map([
+  [".css", "text/css; charset=utf-8"],
+  [".html", "text/html; charset=utf-8"],
+  [".js", "text/javascript; charset=utf-8"],
+  [".json", "application/json; charset=utf-8"],
+  [".png", "image/png"],
+  [".svg", "image/svg+xml"],
+  [".txt", "text/plain; charset=utf-8"],
+  [".webmanifest", "application/manifest+json; charset=utf-8"],
+  [".woff2", "font/woff2"],
+  [".xml", "application/xml; charset=utf-8"],
+]);
+
+function contentType(filePath) {
+  return MIME_TYPES.get(path.extname(filePath).toLowerCase()) ?? "application/octet-stream";
+}
+
+function sitePathFromUrl(requestUrl) {
+  const url = new URL(requestUrl, "http://127.0.0.1");
+  let pathname = decodeURIComponent(url.pathname);
+
+  if (pathname.endsWith("/")) {
+    pathname += "index.html";
+  }
+
+  return pathname.replace(/^\/+/, "");
+}
+
+function resolveInsideSiteRoot(sitePath) {
+  const resolved = path.resolve(SITE_ROOT, sitePath);
+
+  if (resolved !== SITE_ROOT && !resolved.startsWith(`${SITE_ROOT}${path.sep}`)) {
+    return null;
+  }
+
+  return resolved;
+}
+
+async function fileExists(filePath) {
+  try {
+    const stat = await fs.stat(filePath);
+    return stat.isFile();
+  } catch {
+    return false;
+  }
+}
+
+async function directoryIndexExists(filePath) {
+  try {
+    const stat = await fs.stat(filePath);
+    if (!stat.isDirectory()) {
+      return null;
+    }
+
+    const indexPath = path.join(filePath, "index.html");
+    return (await fileExists(indexPath)) ? indexPath : null;
+  } catch {
+    return null;
+  }
+}
+
+async function resolveStaticFile(requestUrl) {
+  const requested = resolveInsideSiteRoot(sitePathFromUrl(requestUrl));
+
+  if (!requested) {
+    return null;
+  }
+
+  if (await fileExists(requested)) {
+    return requested;
+  }
+
+  return directoryIndexExists(requested);
+}
+
+async function serveFile(response, filePath, statusCode = 200) {
+  const body = await fs.readFile(filePath);
+  response.writeHead(statusCode, {
+    "Content-Length": body.byteLength,
+    "Content-Type": contentType(filePath),
+  });
+  response.end(body);
+}
+
+async function handleRequest(request, response) {
+  if (request.method !== "GET" && request.method !== "HEAD") {
+    response.writeHead(405, { Allow: "GET, HEAD" });
+    response.end();
+    return;
+  }
+
+  const filePath = await resolveStaticFile(request.url ?? "/");
+  const finalPath = filePath ?? path.join(SITE_ROOT, "404.html");
+  const statusCode = filePath ? 200 : 404;
+
+  if (request.method === "HEAD") {
+    response.writeHead(statusCode, {
+      "Content-Type": contentType(finalPath),
+    });
+    response.end();
+    return;
+  }
+
+  await serveFile(response, finalPath, statusCode);
+}
+
+const server = http.createServer((request, response) => {
+  handleRequest(request, response).catch((error) => {
+    console.error(error);
+    response.writeHead(500, { "Content-Type": "text/plain; charset=utf-8" });
+    response.end("Internal server error");
+  });
+});
+
+server.listen(port, "127.0.0.1", () => {
+  console.log(`Preview server running at http://127.0.0.1:${port}/`);
+  console.log("Unknown routes fall back to 404.html with status 404.");
+});


### PR DESCRIPTION
## Why

Local QA for missing routes was confusing because python3 -m http.server 4173 serves the built-in Python 404 page instead of the site custom 404.html. In production, GitHub Pages uses the custom 404 page, so a route such as /domains could look broken locally even though the site shell page exists.

Closes #44

## What changed

- Added tools/preview.mjs, a dependency-free Node static server for local previews.
- Preserved normal static route behavior, including directory index routes with and without trailing slashes.
- Added a GitHub Pages-style fallback that serves 404.html with HTTP 404 for unknown routes.
- Documented when to use the simple Python server versus the custom preview helper.

## Why this approach

This keeps the default preview workflow simple while adding a focused helper only for the behavior Python http.server cannot model. It does not change production routing, page design, or the existing static site structure.

## How to review

1. Run node tools/preview.mjs.
2. Open http://127.0.0.1:4173/domains and confirm the custom 404 page renders.
3. Open normal routes such as /, /company, /company/, /results/, and /404.html to confirm they still resolve as expected.

## Validation

- node --check tools/preview.mjs
- node --check tools/check-site-shell.mjs
- node tools/check-site-shell.mjs
- git diff --check

## Testing

Manual local preview checks were run with the helper on port 4174 because port 4173 was already occupied:

- /company returned 200 OK and served the company page.
- /company/ returned 200 OK and served the company page.
- /domains returned 404 Not Found and served 404.html.
- Browser validation confirmed /domains rendered the custom 404 page with Company, Results, and Contact navigation, without the built-in Python error page.