### PR TITLE
Document preview and visual QA checklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Published result pages are generated from the sibling `gother-labs-results` repo
 node tools/sync-results.mjs
 ```
 
-Shared site shell maintenance is documented in `docs/site-shell.md`. Before opening a PR that changes global navigation, metadata, shared assets, or generated result chrome, run:
+Shared site shell maintenance is documented in `docs/site-shell.md`. Preview and visual QA expectations are documented in `docs/preview-qa.md`. Before opening a PR that changes global navigation, metadata, shared assets, or generated result chrome, run:
 
 ```bash
 node tools/check-site-shell.mjs

--- a/docs/preview-qa.md
+++ b/docs/preview-qa.md
@@ -1,0 +1,93 @@
+# Preview And Visual QA Checklist
+
+Use this checklist before opening PRs that can affect shared navigation, the site shell, responsive layout, generated result pages, or route-level metadata. The workflow stays intentionally lightweight: structural checks first, then targeted browser review.
+
+## Preview Server
+
+For most static route checks:
+
+```bash
+python3 -m http.server 4173
+```
+
+For GitHub Pages-style custom 404 behavior:
+
+```bash
+node tools/preview.mjs
+```
+
+If port `4173` is already in use, pass another port:
+
+```bash
+node tools/preview.mjs 4174
+```
+
+Use the same server for the whole QA pass so screenshots and observations are comparable.
+
+## Structural Checks
+
+Run these before browser review:
+
+```bash
+node tools/check-site-shell.mjs
+git diff --check
+```
+
+For generated-results changes, also run:
+
+```bash
+node tools/sync-results.mjs
+```
+
+Then review the generated diff before committing. Shell-sensitive changes should not introduce unrelated editorial changes.
+
+## Route Set
+
+Inspect this route set for shell-sensitive PRs:
+
+| Route | Purpose |
+| --- | --- |
+| `/` | Home exception: hero wordmark may replace header brand. |
+| `/company/` | Standard hand-authored shell page. |
+| `/contact/` | Standard hand-authored shell page and footer behavior. |
+| `/results/` | Generated results index shell. |
+| `/results/quadrature-rule-optimization/` | Generated result detail page with MathJax exception. |
+| `/results/quadrature-rule-optimization/run/` | Copied run page shell normalization. |
+| `/404.html` | Hand-authored custom 404 shell. |
+| `/domains` | Missing-route fallback when using `node tools/preview.mjs`. |
+| `/evolther/` | Experimental page with route-specific shell and responsive behavior. |
+
+If a PR changes RCPSP-specific result rendering, inspect `/results/rcpsp-psplib-j30/` and `/results/rcpsp-psplib-j30/run/` as well.
+
+## Visual Checks
+
+Review each affected route at:
+
+- Desktop: approximately `1440 x 900`.
+- Laptop: approximately `1280 x 800`.
+- Mobile: approximately `390 x 844`.
+
+For each viewport, verify:
+
+- Header navigation is visible, aligned, and ordered `Company`, `Results`, `Contact`.
+- The animated wordmark appears with the expected colored symbol dots where the shared shell uses it.
+- Text does not wrap unexpectedly or overlap adjacent content.
+- There is no horizontal overflow.
+- Footer presence or absence matches the documented shell exceptions.
+- Route-specific diagrams, cards, or visual assets remain legible.
+- Dark and light mode render critical lines, arrows, symbols, and labels with enough contrast when the page supports both modes.
+
+## Generated Results Checks
+
+When `tools/sync-results.mjs` or generated result files change:
+
+- Confirm generated pages keep `styles.css?v=nav-wordmark-v1` and `scripts.js?v=nav-wordmark-v1`.
+- Confirm generated pages use the current wordmark shell and `.nav-links` wrapper.
+- Confirm copied run pages keep their expected noindex behavior.
+- Confirm generated result diffs are limited to intended shell, metadata, or result-content changes.
+
+## Evidence
+
+Do not commit screenshots or generated visual reports by default. Attach screenshots to the PR only when they clarify a visual decision, responsive fix, or before/after regression.
+
+In the PR body, list the structural commands run and the routes/viewport classes spot-checked.

--- a/docs/site-shell.md
+++ b/docs/site-shell.md
@@ -64,7 +64,7 @@ When changing global shell behavior:
    - `evolther/` and copied run pages may include `robots` noindex directives and may omit canonical/social metadata.
    - Result detail pages may include MathJax.
 5. Run the shell checker before opening a PR.
-6. Preview representative routes with a static server.
+6. Preview representative routes with a static server and the visual QA checklist in `docs/preview-qa.md`.
 
 ## Verification
 
@@ -79,7 +79,7 @@ python3 -m http.server 4173
 
 Use `python3 -m http.server 4173` for the simplest static preview. Use `node tools/preview.mjs` when validating GitHub Pages-style 404 fallback behavior for unknown routes such as `/domains`; Python's built-in server shows its own error page for those routes. If port `4173` is already in use, run `node tools/preview.mjs 4174`.
 
-Then spot-check:
+Then follow the preview and visual QA checklist in `docs/preview-qa.md`. At minimum, spot-check:
 
 - `/`
 - `/company/`
@@ -97,5 +97,5 @@ Split future work into focused issues if this checklist is no longer enough:
 - Extract shared shell primitives into a small helper used by generated pages.
 - Normalize metadata and canonical handling across hand-authored pages.
 - Strengthen result generator shell integration.
-- Add a stricter preview and visual QA checklist.
+- Keep the preview and visual QA checklist current as new shell-sensitive pages are added.
 - Reconsider a static-site generator only if the manual/static model becomes a real maintenance bottleneck.


### PR DESCRIPTION
## Why

Shell-sensitive changes currently have structural validation, but the browser preview expectations are spread across habit and issue history. That makes it easy to forget route coverage, viewport coverage, or the distinction between structural checks and visual review.

Closes #43

## What changed

- Added docs/preview-qa.md with a repeatable preview and visual QA checklist.
- Documented the expected preview server choices, including the custom 404 preview helper.
- Defined the standard shell-sensitive route set: home, company, contact, results index, result detail, copied run page, 404, missing-route fallback, and evolther.
- Added desktop, laptop, and mobile viewport guidance.
- Added generated-results-specific checks for shell versioning, nav structure, run page noindex behavior, and diff scope.
- Linked the checklist from README.md and docs/site-shell.md.

## Why this approach

This keeps the workflow lightweight and compatible with the static GitHub Pages site. It adds review discipline without introducing screenshot artifacts, generated reports, browser automation, or a heavier build pipeline.

## How to review

1. Read docs/preview-qa.md and confirm the checklist is clear enough to run before shell-sensitive PRs.
2. Confirm docs/site-shell.md now points maintainers to the visual QA checklist.
3. Confirm README.md surfaces the checklist alongside the existing shell checker.

## Validation

- node tools/check-site-shell.mjs
- node --check tools/preview.mjs
- node --check tools/sync-results.mjs
- node tools/sync-results.mjs with a temporary sibling symlink to the local gother-labs-results repository
- git diff --check

## Testing

Using node tools/preview.mjs on port 4174, the documented route set was smoke-tested:

- / returned 200
- /company/ returned 200
- /contact/ returned 200
- /results/ returned 200
- /results/quadrature-rule-optimization/ returned 200
- /results/quadrature-rule-optimization/run/ returned 200
- /404.html returned 200
- /domains returned 404 with the custom 404 fallback
- /evolther/ returned 200