### PR TITLE
Clarify generated results shell boundary

### DIFF
--- a/docs/site-shell.md
+++ b/docs/site-shell.md
@@ -29,6 +29,15 @@ The generated shell currently appears in:
 - `results/*/index.html`
 - copied result run pages under `results/*/run/index.html`, normalized by `tools/sync-results.mjs`
 
+Inside `tools/sync-results.mjs`, generated shell ownership is intentionally limited to:
+
+- `SITE_SHELL_VERSION` and `SHARED_SITE_SHELL` for shared asset versioning and nav labels.
+- `nav(prefix)` for the generated header.
+- `htmlShell(...)` for generated result index and detail pages.
+- `alignCopiedRunShell(...)` / `normalizeCopiedRunShell(...)` for copied run-page shell normalization.
+
+Result content renderers should stay below that boundary and use `htmlShell(...)` rather than emitting their own top-level chrome.
+
 `careers/index.html` is a legacy redirect and is intentionally excluded from the shared shell checklist.
 
 ## Decision

--- a/tools/sync-results.mjs
+++ b/tools/sync-results.mjs
@@ -9,9 +9,42 @@ const RESULTS_ROOT = path.resolve(SITE_ROOT, "..", "gother-labs-results");
 const CATALOG_PATH = path.join(RESULTS_ROOT, "catalog.json");
 const OUT_ROOT = path.join(SITE_ROOT, "results");
 
-// Keep this shell version aligned with the hand-authored pages.
+// Results pages are generated here, but the shared site shell must stay aligned
+// with the hand-authored pages documented in docs/site-shell.md.
 const SITE_SHELL_VERSION = "nav-wordmark-v1";
 const SITE_URL = "https://www.gotherlabs.com";
+const SHARED_SITE_SHELL = Object.freeze({
+  version: SITE_SHELL_VERSION,
+  fontPreloadHref: "/assets/fonts/inter-latin.woff2",
+  faviconPath: "assets/gother-mark.svg",
+  stylesheetPath: "styles.css",
+  scriptPath: "scripts.js",
+  navLinks: Object.freeze([
+    ["company/", "Company"],
+    ["results/", "Results"],
+    ["contact/", "Contact"],
+  ]),
+});
+
+function versionedSharedAsset(prefix, assetPath) {
+  return `${prefix}${assetPath}?v=${SHARED_SITE_SHELL.version}`;
+}
+
+function sharedStylesheetTag(prefix) {
+  return `<link rel="stylesheet" href="${versionedSharedAsset(prefix, SHARED_SITE_SHELL.stylesheetPath)}">`;
+}
+
+function sharedScriptTag(prefix) {
+  return `<script src="${versionedSharedAsset(prefix, SHARED_SITE_SHELL.scriptPath)}"></script>`;
+}
+
+function sharedFaviconTag(prefix) {
+  return `<link rel="icon" href="${prefix}${SHARED_SITE_SHELL.faviconPath}" type="image/svg+xml">`;
+}
+
+function sharedFontPreloadTag() {
+  return `<link rel="preload" href="${SHARED_SITE_SHELL.fontPreloadHref}" as="font" type="font/woff2" crossorigin>`;
+}
 
 function escapeHtml(value) {
   return String(value ?? "")
@@ -156,6 +189,10 @@ function articleWithoutTitle(markdown) {
 }
 
 function nav(prefix) {
+  const links = SHARED_SITE_SHELL.navLinks
+    .map(([href, label]) => `<a href="${prefix}${href}">${label}</a>`)
+    .join("\n            ");
+
   return `<header class="site-header">
         <nav class="site-nav" aria-label="Primary">
           <a class="brand nav-brand nav-home-wordmark animated-symbol-scope" href="${prefix}" aria-label="Göther Labs home">
@@ -177,12 +214,23 @@ function nav(prefix) {
             <span class="nav-wordmark-text">Göther Labs</span>
           </a>
           <div class="nav-links">
-            <a href="${prefix}company/">Company</a>
-            <a href="${prefix}results/">Results</a>
-            <a href="${prefix}contact/">Contact</a>
+            ${links}
           </div>
         </nav>
       </header>`;
+}
+
+function normalizeCopiedRunShell(html, prefix) {
+  return html
+    .replace(
+      /<link rel="stylesheet" href="\.\.\/\.\.\/\.\.\/styles\.css(?:\?v=[^"]*)?">/,
+      sharedStylesheetTag(prefix),
+    )
+    .replace(/<header class="site-header">[\s\S]*?<\/header>/, nav(prefix))
+    .replace(
+      /<script src="\.\.\/\.\.\/\.\.\/scripts\.js(?:\?v=[^"]*)?"><\/script>/,
+      sharedScriptTag(prefix),
+    );
 }
 
 async function alignCopiedRunShell(outputRoot) {
@@ -197,16 +245,7 @@ async function alignCopiedRunShell(outputRoot) {
   }
 
   const runPrefix = "../../../";
-  const aligned = html
-    .replace(
-      /<link rel="stylesheet" href="\.\.\/\.\.\/\.\.\/styles\.css(?:\?v=[^"]*)?">/,
-      `<link rel="stylesheet" href="${runPrefix}styles.css?v=${SITE_SHELL_VERSION}">`,
-    )
-    .replace(/<header class="site-header">[\s\S]*?<\/header>/, nav(runPrefix))
-    .replace(
-      /<script src="\.\.\/\.\.\/\.\.\/scripts\.js(?:\?v=[^"]*)?"><\/script>/,
-      `<script src="${runPrefix}scripts.js?v=${SITE_SHELL_VERSION}"></script>`,
-    );
+  const aligned = normalizeCopiedRunShell(html, runPrefix);
 
   if (aligned !== html) {
     await fs.writeFile(runIndexPath, aligned, "utf8");
@@ -250,9 +289,9 @@ function htmlShell({ title, description, canonicalPath, cssPrefix, body, enableM
     <meta property="og:image" content="${SITE_URL}/assets/og-image.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:image" content="${SITE_URL}/assets/og-image.png">
-    <link rel="preload" href="/assets/fonts/inter-latin.woff2" as="font" type="font/woff2" crossorigin>
-    <link rel="icon" href="${cssPrefix}assets/gother-mark.svg" type="image/svg+xml">
-    <link rel="stylesheet" href="${cssPrefix}styles.css?v=${SITE_SHELL_VERSION}">
+    ${sharedFontPreloadTag()}
+    ${sharedFaviconTag(cssPrefix)}
+    ${sharedStylesheetTag(cssPrefix)}
 ${enableMath ? mathHead() : ""}
   </head>
   <body${bodyClassAttribute}>
@@ -269,7 +308,7 @@ ${body}
       </footer>
     </div>
 
-    <script src="${cssPrefix}scripts.js?v=${SITE_SHELL_VERSION}"></script>
+    ${sharedScriptTag(cssPrefix)}
   </body>
 </html>
 `;


### PR DESCRIPTION
## Why

The results generator owns generated result pages and copied run-page shell normalization. The shell-specific pieces were correct, but they were embedded directly alongside result rendering, which made future shell maintenance harder to review.

Closes #42

## What changed

- Added a `SHARED_SITE_SHELL` boundary in `tools/sync-results.mjs` for shell version, shared asset paths, and nav labels.
- Added small helpers for versioned stylesheet/script tags, favicon, and font preload output.
- Updated `nav(prefix)` to use the shared nav label/link configuration.
- Extracted copied run-page shell replacement into `normalizeCopiedRunShell(...)`.
- Documented the generated shell ownership boundary in `docs/site-shell.md`.

## Why this approach

This keeps `sync-results` as the owner of generated result shell output without introducing a framework or separate template system. The refactor is intentionally small and keeps result content rendering behavior unchanged.

## How to review

1. Review the helper extraction near the top of `tools/sync-results.mjs`.
2. Confirm `nav(prefix)`, `htmlShell(...)`, and copied run-page normalization still emit the same shared shell structure.
3. Review `docs/site-shell.md` for the documented generator boundary.

## Validation

- `node --check tools/sync-results.mjs`
- `node tools/sync-results.mjs` with a temporary sibling symlink to the local `gother-labs-results` repository
- `node tools/check-site-shell.mjs`
- `git diff --check`

## Testing

After running `node tools/sync-results.mjs`, no generated public HTML files were modified. The only committed changes are the generator refactor and shell-maintenance documentation.