### PR TITLE
Normalize public route metadata policy

### DIFF
--- a/docs/site-shell.md
+++ b/docs/site-shell.md
@@ -51,6 +51,25 @@ The operational source of truth is:
 - `SITE_SHELL_VERSION` in `tools/sync-results.mjs` and hand-authored `styles.css` / `scripts.js` query strings must stay aligned.
 - Per-page metadata stays local when it is intentionally page-specific, such as home copy, canonical paths, `robots` directives for experimental/noindex pages, and MathJax on result detail pages.
 
+## Metadata Policy
+
+Indexable public pages must include:
+
+- A page-specific `<title>`.
+- A page-specific `meta name="description"`.
+- A canonical URL.
+- Open Graph title, description, URL, image, and type metadata.
+- Twitter card and image metadata.
+- Inter font preload and favicon links.
+
+The documented noindex exceptions are:
+
+- `404.html`
+- `evolther/index.html`
+- copied run pages under `results/*/run/index.html`
+
+Those exception pages must keep `meta name="robots"` with `noindex`. They may omit canonical, Open Graph, and Twitter metadata when the route is intentionally non-indexable.
+
 This is the smallest approach that prevents shell drift while preserving the repository's no-build deployment model.
 
 ## Rejected Alternatives

--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
       name="description"
       content="Göther Labs is building an operating system for governed improvement loops: offline-first, auditable, and designed for real constraints."
     >
+    <link rel="canonical" href="https://www.gotherlabs.com/">
     <meta property="og:title" content="Göther Labs | Operating System for Governed Improvement">
     <meta
       property="og:description"

--- a/tools/check-site-shell.mjs
+++ b/tools/check-site-shell.mjs
@@ -97,23 +97,22 @@ function checkFooter(html, failures, route) {
   assert(html.includes(`class="site-footer"`), failures, route, "missing site footer");
 }
 
-function checkMetadata(html, failures, route, { home = false } = {}) {
+function checkMetadata(html, failures, route) {
   assert(html.includes(`<title>`), failures, route, "missing title");
   assert(html.includes(`name="description"`), failures, route, "missing description metadata");
 
-  if (home) {
-    assert(html.includes(`property="og:url"`), failures, route, "missing home Open Graph URL");
-    assert(html.includes(`property="og:image"`), failures, route, "missing home Open Graph image");
+  if (METADATA_OPTIONAL.has(route) || route.endsWith("/run/index.html")) {
+    assert(html.includes(`name="robots"`) && html.includes(`noindex`), failures, route, "metadata exception must be noindex");
     return;
   }
 
-  if (!METADATA_OPTIONAL.has(route) && !route.endsWith("/run/index.html")) {
-    assert(html.includes(`rel="canonical"`), failures, route, "missing canonical URL");
-    assert(html.includes(`property="og:title"`), failures, route, "missing Open Graph title");
-    assert(html.includes(`property="og:description"`), failures, route, "missing Open Graph description");
-    assert(html.includes(`property="og:url"`), failures, route, "missing Open Graph URL");
-    assert(html.includes(`property="og:image"`), failures, route, "missing Open Graph image");
-  }
+  assert(html.includes(`rel="canonical"`), failures, route, "missing canonical URL");
+  assert(html.includes(`property="og:title"`), failures, route, "missing Open Graph title");
+  assert(html.includes(`property="og:description"`), failures, route, "missing Open Graph description");
+  assert(html.includes(`property="og:url"`), failures, route, "missing Open Graph URL");
+  assert(html.includes(`property="og:image"`), failures, route, "missing Open Graph image");
+  assert(html.includes(`name="twitter:card"`) && html.includes(`summary_large_image`), failures, route, "missing Twitter card metadata");
+  assert(html.includes(`name="twitter:image"`), failures, route, "missing Twitter image metadata");
 }
 
 async function main() {
@@ -129,7 +128,7 @@ async function main() {
     assert(html.startsWith("<!doctype html>"), failures, route, "missing HTML doctype");
     assert(html.includes(`id="site-main"`) || route.endsWith("/run/index.html"), failures, route, "missing site-main anchor");
 
-    checkMetadata(html, failures, route, { home });
+    checkMetadata(html, failures, route);
     checkSharedAssets(html, failures, route);
     checkNav(html, failures, route, { home });
     checkFooter(html, failures, route);


### PR DESCRIPTION
## Why

Metadata policy was documented at a high level, but the checker still treated the home page as a special case and did not enforce the full canonical, Open Graph, and Twitter metadata surface for indexable pages. The home page was also missing an explicit canonical URL.

Closes #41

## What changed

- Added a canonical URL to `index.html`.
- Documented the metadata policy in `docs/site-shell.md`.
- Documented the intentional noindex exceptions: `404.html`, `evolther/index.html`, and copied result run pages.
- Strengthened `tools/check-site-shell.mjs` so indexable pages require canonical, Open Graph, and Twitter card/image metadata.
- Strengthened noindex exception validation so exception routes must keep `meta name="robots"` with `noindex`.

## Why this approach

This normalizes the existing static pages without adding a metadata generator or framework. It preserves the intentional noindex behavior for experimental and copied run pages while making indexable public routes more predictable.

## How to review

1. Confirm `index.html` now includes `rel="canonical"` for `https://www.gotherlabs.com/`.
2. Review the metadata policy added to `docs/site-shell.md`.
3. Review the checker changes and confirm the stricter rules match the documented policy.

## Validation

- `node --check tools/check-site-shell.mjs`
- `node --check tools/sync-results.mjs`
- `node tools/check-site-shell.mjs`
- `node tools/sync-results.mjs` with a temporary sibling symlink to the local `gother-labs-results` repository
- `git diff --check`

## Testing

Preview route smoke test with `python3 -m http.server 4174`:

- `/` returned 200
- `/company/` returned 200
- `/contact/` returned 200
- `/results/` returned 200
- `/results/quadrature-rule-optimization/` returned 200
- `/results/quadrature-rule-optimization/run/` returned 200
- `/404.html` returned 200
- `/evolther/` returned 200