### PR TITLE
Extract minimal generated site shell primitives

### DIFF
--- a/docs/site-shell.md
+++ b/docs/site-shell.md
@@ -29,14 +29,15 @@ The generated shell currently appears in:
 - `results/*/index.html`
 - copied result run pages under `results/*/run/index.html`, normalized by `tools/sync-results.mjs`
 
-Inside `tools/sync-results.mjs`, generated shell ownership is intentionally limited to:
+Shared shell primitives live in `tools/site-shell.mjs`. The helper is intentionally small and currently owns:
 
 - `SITE_SHELL_VERSION` and `SHARED_SITE_SHELL` for shared asset versioning and nav labels.
-- `nav(prefix)` for the generated header.
-- `htmlShell(...)` for generated result index and detail pages.
-- `alignCopiedRunShell(...)` / `normalizeCopiedRunShell(...)` for copied run-page shell normalization.
+- Shared font preload, favicon, stylesheet, and script tag helpers.
+- `sharedNav(prefix)` for generated headers.
+- `sharedFooter()` for generated footers.
+- `normalizeCopiedRunShell(...)` for copied run-page shell normalization.
 
-Result content renderers should stay below that boundary and use `htmlShell(...)` rather than emitting their own top-level chrome.
+`tools/sync-results.mjs` still owns generated result metadata and body structure through `htmlShell(...)`. Result content renderers should stay below that boundary and use `htmlShell(...)` rather than emitting their own top-level chrome.
 
 `careers/index.html` is a legacy redirect and is intentionally excluded from the shared shell checklist.
 
@@ -47,8 +48,9 @@ Keep the site static and hand-authored for now. Do not introduce a framework, fu
 The operational source of truth is:
 
 - `tools/sync-results.mjs` owns generated result pages and copied run-page shell normalization.
+- `tools/site-shell.mjs` owns the minimal generated shell primitives shared by `tools/sync-results.mjs` and `tools/check-site-shell.mjs`.
 - Hand-authored pages remain manually edited, but they must follow this document and `node tools/check-site-shell.mjs`.
-- `SITE_SHELL_VERSION` in `tools/sync-results.mjs` and hand-authored `styles.css` / `scripts.js` query strings must stay aligned.
+- `SITE_SHELL_VERSION` in `tools/site-shell.mjs` and hand-authored `styles.css` / `scripts.js` query strings must stay aligned.
 - Per-page metadata stays local when it is intentionally page-specific, such as home copy, canonical paths, `robots` directives for experimental/noindex pages, and MathJax on result detail pages.
 
 ## Metadata Policy

--- a/tools/check-site-shell.mjs
+++ b/tools/check-site-shell.mjs
@@ -2,17 +2,14 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { REQUIRED_NAV_LABELS, SITE_SHELL_VERSION } from "./site-shell.mjs";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const SITE_ROOT = path.resolve(__dirname, "..");
-const SHELL_VERSION = "nav-wordmark-v1";
-
 const REDIRECT_EXCEPTIONS = new Set(["careers/index.html"]);
 const HOME_PAGE = "index.html";
 const FOOTER_OPTIONAL = new Set(["index.html", "404.html"]);
 const METADATA_OPTIONAL = new Set(["404.html", "evolther/index.html"]);
-
-const requiredNavLabels = ["Company", "Results", "Contact"];
 
 async function collectHtmlFiles(dir = SITE_ROOT) {
   const entries = await fs.readdir(dir, { withFileTypes: true });
@@ -63,16 +60,16 @@ function checkSharedAssets(html, failures, route) {
   );
   assert(html.includes(`assets/gother-mark.svg`) && html.includes(`rel="icon"`), failures, route, "missing favicon");
   assert(
-    html.includes(`styles.css?v=${SHELL_VERSION}`),
+    html.includes(`styles.css?v=${SITE_SHELL_VERSION}`),
     failures,
     route,
-    `missing shared stylesheet version ${SHELL_VERSION}`,
+    `missing shared stylesheet version ${SITE_SHELL_VERSION}`,
   );
   assert(
-    html.includes(`scripts.js?v=${SHELL_VERSION}`),
+    html.includes(`scripts.js?v=${SITE_SHELL_VERSION}`),
     failures,
     route,
-    `missing shared script version ${SHELL_VERSION}`,
+    `missing shared script version ${SITE_SHELL_VERSION}`,
   );
 }
 
@@ -86,7 +83,7 @@ function checkNav(html, failures, route, { home = false } = {}) {
     assert(html.includes(`class="nav-links"`), failures, route, "missing nav links wrapper");
   }
 
-  for (const label of requiredNavLabels) {
+  for (const label of REQUIRED_NAV_LABELS) {
     assert(new RegExp(`<a\\s[^>]*>${label}</a>`).test(html), failures, route, `missing ${label} nav link`);
   }
 }

--- a/tools/site-shell.mjs
+++ b/tools/site-shell.mjs
@@ -1,0 +1,89 @@
+// Shared primitives for generated shell output and shell validation.
+// Hand-authored HTML remains committed directly; keep this boundary small.
+export const SITE_SHELL_VERSION = "nav-wordmark-v1";
+
+export const SHARED_SITE_SHELL = Object.freeze({
+  version: SITE_SHELL_VERSION,
+  fontPreloadHref: "/assets/fonts/inter-latin.woff2",
+  faviconPath: "assets/gother-mark.svg",
+  stylesheetPath: "styles.css",
+  scriptPath: "scripts.js",
+  navLinks: Object.freeze([
+    ["company/", "Company"],
+    ["results/", "Results"],
+    ["contact/", "Contact"],
+  ]),
+});
+
+export const REQUIRED_NAV_LABELS = SHARED_SITE_SHELL.navLinks.map(([_href, label]) => label);
+
+export function versionedSharedAsset(prefix, assetPath) {
+  return `${prefix}${assetPath}?v=${SHARED_SITE_SHELL.version}`;
+}
+
+export function sharedStylesheetTag(prefix) {
+  return `<link rel="stylesheet" href="${versionedSharedAsset(prefix, SHARED_SITE_SHELL.stylesheetPath)}">`;
+}
+
+export function sharedScriptTag(prefix) {
+  return `<script src="${versionedSharedAsset(prefix, SHARED_SITE_SHELL.scriptPath)}"></script>`;
+}
+
+export function sharedFaviconTag(prefix) {
+  return `<link rel="icon" href="${prefix}${SHARED_SITE_SHELL.faviconPath}" type="image/svg+xml">`;
+}
+
+export function sharedFontPreloadTag() {
+  return `<link rel="preload" href="${SHARED_SITE_SHELL.fontPreloadHref}" as="font" type="font/woff2" crossorigin>`;
+}
+
+export function sharedNav(prefix) {
+  const links = SHARED_SITE_SHELL.navLinks
+    .map(([href, label]) => `<a href="${prefix}${href}">${label}</a>`)
+    .join("\n            ");
+
+  return `<header class="site-header">
+        <nav class="site-nav" aria-label="Primary">
+          <a class="brand nav-brand nav-home-wordmark animated-symbol-scope" href="${prefix}" aria-label="Göther Labs home">
+            <span aria-hidden="true" class="wordmark-mark-wrap">
+              <svg class="animated-reference-geometry live-symbol-svg" viewBox="0 0 64 64" focusable="false">
+                <g class="source-geometry" aria-hidden="true">
+                  <circle class="source-geometry-dot" cx="34.5" cy="34.5" r="3.6" />
+                  <circle class="source-geometry-dot" cx="21" cy="58" r="3.6" />
+                  <circle class="source-geometry-dot" cx="48" cy="58" r="3.6" />
+                </g>
+                <path class="live-trail" d="" />
+                <path class="live-trail" d="" />
+                <path class="live-trail" d="" />
+                <circle class="geometry-dot live-geometry-dot" cx="34.2" cy="28.4" r="3.34" />
+                <circle class="geometry-dot live-geometry-dot" cx="20.9" cy="50.6" r="3.34" />
+                <circle class="geometry-dot live-geometry-dot" cx="47.5" cy="50.6" r="3.34" />
+              </svg>
+            </span>
+            <span class="nav-wordmark-text">Göther Labs</span>
+          </a>
+          <div class="nav-links">
+            ${links}
+          </div>
+        </nav>
+      </header>`;
+}
+
+export function sharedFooter() {
+  return `<footer class="site-footer">
+        <p>© <span id="year">2026</span> Göther Labs</p>
+      </footer>`;
+}
+
+export function normalizeCopiedRunShell(html, prefix) {
+  return html
+    .replace(
+      /<link rel="stylesheet" href="\.\.\/\.\.\/\.\.\/styles\.css(?:\?v=[^"]*)?">/,
+      sharedStylesheetTag(prefix),
+    )
+    .replace(/<header class="site-header">[\s\S]*?<\/header>/, sharedNav(prefix))
+    .replace(
+      /<script src="\.\.\/\.\.\/\.\.\/scripts\.js(?:\?v=[^"]*)?"><\/script>/,
+      sharedScriptTag(prefix),
+    );
+}

--- a/tools/sync-results.mjs
+++ b/tools/sync-results.mjs
@@ -2,6 +2,15 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import {
+  normalizeCopiedRunShell,
+  sharedFaviconTag,
+  sharedFontPreloadTag,
+  sharedFooter,
+  sharedNav,
+  sharedScriptTag,
+  sharedStylesheetTag,
+} from "./site-shell.mjs";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const SITE_ROOT = path.resolve(__dirname, "..");
@@ -9,42 +18,7 @@ const RESULTS_ROOT = path.resolve(SITE_ROOT, "..", "gother-labs-results");
 const CATALOG_PATH = path.join(RESULTS_ROOT, "catalog.json");
 const OUT_ROOT = path.join(SITE_ROOT, "results");
 
-// Results pages are generated here, but the shared site shell must stay aligned
-// with the hand-authored pages documented in docs/site-shell.md.
-const SITE_SHELL_VERSION = "nav-wordmark-v1";
 const SITE_URL = "https://www.gotherlabs.com";
-const SHARED_SITE_SHELL = Object.freeze({
-  version: SITE_SHELL_VERSION,
-  fontPreloadHref: "/assets/fonts/inter-latin.woff2",
-  faviconPath: "assets/gother-mark.svg",
-  stylesheetPath: "styles.css",
-  scriptPath: "scripts.js",
-  navLinks: Object.freeze([
-    ["company/", "Company"],
-    ["results/", "Results"],
-    ["contact/", "Contact"],
-  ]),
-});
-
-function versionedSharedAsset(prefix, assetPath) {
-  return `${prefix}${assetPath}?v=${SHARED_SITE_SHELL.version}`;
-}
-
-function sharedStylesheetTag(prefix) {
-  return `<link rel="stylesheet" href="${versionedSharedAsset(prefix, SHARED_SITE_SHELL.stylesheetPath)}">`;
-}
-
-function sharedScriptTag(prefix) {
-  return `<script src="${versionedSharedAsset(prefix, SHARED_SITE_SHELL.scriptPath)}"></script>`;
-}
-
-function sharedFaviconTag(prefix) {
-  return `<link rel="icon" href="${prefix}${SHARED_SITE_SHELL.faviconPath}" type="image/svg+xml">`;
-}
-
-function sharedFontPreloadTag() {
-  return `<link rel="preload" href="${SHARED_SITE_SHELL.fontPreloadHref}" as="font" type="font/woff2" crossorigin>`;
-}
 
 function escapeHtml(value) {
   return String(value ?? "")
@@ -188,51 +162,6 @@ function articleWithoutTitle(markdown) {
   return markdown.replace(/\r\n/g, "\n").replace(/^#\s+.+\n+/, "");
 }
 
-function nav(prefix) {
-  const links = SHARED_SITE_SHELL.navLinks
-    .map(([href, label]) => `<a href="${prefix}${href}">${label}</a>`)
-    .join("\n            ");
-
-  return `<header class="site-header">
-        <nav class="site-nav" aria-label="Primary">
-          <a class="brand nav-brand nav-home-wordmark animated-symbol-scope" href="${prefix}" aria-label="Göther Labs home">
-            <span aria-hidden="true" class="wordmark-mark-wrap">
-              <svg class="animated-reference-geometry live-symbol-svg" viewBox="0 0 64 64" focusable="false">
-                <g class="source-geometry" aria-hidden="true">
-                  <circle class="source-geometry-dot" cx="34.5" cy="34.5" r="3.6" />
-                  <circle class="source-geometry-dot" cx="21" cy="58" r="3.6" />
-                  <circle class="source-geometry-dot" cx="48" cy="58" r="3.6" />
-                </g>
-                <path class="live-trail" d="" />
-                <path class="live-trail" d="" />
-                <path class="live-trail" d="" />
-                <circle class="geometry-dot live-geometry-dot" cx="34.2" cy="28.4" r="3.34" />
-                <circle class="geometry-dot live-geometry-dot" cx="20.9" cy="50.6" r="3.34" />
-                <circle class="geometry-dot live-geometry-dot" cx="47.5" cy="50.6" r="3.34" />
-              </svg>
-            </span>
-            <span class="nav-wordmark-text">Göther Labs</span>
-          </a>
-          <div class="nav-links">
-            ${links}
-          </div>
-        </nav>
-      </header>`;
-}
-
-function normalizeCopiedRunShell(html, prefix) {
-  return html
-    .replace(
-      /<link rel="stylesheet" href="\.\.\/\.\.\/\.\.\/styles\.css(?:\?v=[^"]*)?">/,
-      sharedStylesheetTag(prefix),
-    )
-    .replace(/<header class="site-header">[\s\S]*?<\/header>/, nav(prefix))
-    .replace(
-      /<script src="\.\.\/\.\.\/\.\.\/scripts\.js(?:\?v=[^"]*)?"><\/script>/,
-      sharedScriptTag(prefix),
-    );
-}
-
 async function alignCopiedRunShell(outputRoot) {
   // Run surfaces are copied from the results repo, so normalize their shared site shell here.
   const runIndexPath = path.join(outputRoot, "run", "index.html");
@@ -297,15 +226,13 @@ ${enableMath ? mathHead() : ""}
   <body${bodyClassAttribute}>
     <a class="skip-link" href="#site-main">Skip to content</a>
     <div class="page-shell site-shell">
-      ${nav(cssPrefix)}
+      ${sharedNav(cssPrefix)}
 
       <main class="site-main" id="site-main">
 ${body}
       </main>
 
-      <footer class="site-footer">
-        <p>© <span id="year">2026</span> Göther Labs</p>
-      </footer>
+      ${sharedFooter()}
     </div>
 
     ${sharedScriptTag(cssPrefix)}


### PR DESCRIPTION
## Why

The shared site shell was still partially duplicated between `tools/sync-results.mjs` and shell validation. Previous issues documented the conservative maintenance model and clarified the generated shell boundary; this PR extracts the smallest useful helper without introducing a framework or regenerating hand-authored pages.

Closes #40

## What changed

- Added `tools/site-shell.mjs` as the minimal shared primitive boundary.
- Moved shared shell version, shared asset paths, nav labels, versioned stylesheet/script helpers, favicon/font preload helpers, generated nav, generated footer, and copied run-page shell normalization into the helper.
- Updated `tools/sync-results.mjs` to use the helper for generated result pages and copied run-page normalization.
- Updated `tools/check-site-shell.mjs` to read shell version and nav labels from the same helper.
- Updated `docs/site-shell.md` to document the new helper boundary and keep hand-authored pages manual.

## Why this approach

This extracts only the implementation surface that was already shared by generated pages and validation. It does not add a framework, a static-site generator, bulk regeneration for hand-authored pages, or shared metadata generation.

## How to review

1. Review `tools/site-shell.mjs` as the new primitive boundary.
2. Confirm `tools/sync-results.mjs` now delegates generated nav/footer/assets/run-page normalization to that helper.
3. Confirm `tools/check-site-shell.mjs` validates against the same shell version and nav labels.
4. Confirm `docs/site-shell.md` still preserves the manual/static model for hand-authored pages.

## Validation

- `node --check tools/site-shell.mjs`
- `node --check tools/sync-results.mjs`
- `node --check tools/check-site-shell.mjs`
- `node tools/check-site-shell.mjs`
- `node tools/sync-results.mjs` with a temporary sibling symlink to the local `gother-labs-results` repository
- `git diff --check`

## Testing

After running `node tools/sync-results.mjs`, no generated public HTML files were modified. The committed changes are limited to the helper extraction, generator/checker integration, and shell-maintenance documentation.