### PR TITLE
[codex] Prioritize results nav and scale wordmark

### DIFF
--- a/404.html
+++ b/404.html
@@ -8,7 +8,7 @@
     <meta name="robots" content="noindex">
     <link rel="preload" href="/assets/fonts/inter-latin.woff2" as="font" type="font/woff2" crossorigin>
     <link rel="icon" href="./assets/gother-mark.svg" type="image/svg+xml">
-    <link rel="stylesheet" href="./styles.css?v=nav-wordmark-v1">
+    <link rel="stylesheet" href="./styles.css?v=nav-wordmark-v2">
   </head>
   <body class="not-found-page">
     <a class="skip-link" href="#site-main">Skip to content</a>
@@ -34,8 +34,8 @@
             <span class="nav-wordmark-text">Göther Labs</span>
           </a>
           <div class="nav-links">
-            <a href="./company/">Company</a>
             <a href="./results/">Results</a>
+            <a href="./company/">Company</a>
             <a href="./contact/">Contact</a>
           </div>
         </nav>
@@ -73,6 +73,6 @@
       </main>
     </div>
 
-    <script src="./scripts.js?v=nav-wordmark-v1"></script>
+    <script src="./scripts.js?v=nav-wordmark-v2"></script>
   </body>
 </html>

--- a/company/index.html
+++ b/company/index.html
@@ -21,7 +21,7 @@
     <meta name="twitter:image" content="https://www.gotherlabs.com/assets/og-image.png">
     <link rel="preload" href="/assets/fonts/inter-latin.woff2" as="font" type="font/woff2" crossorigin>
     <link rel="icon" href="../assets/gother-mark.svg" type="image/svg+xml">
-    <link rel="stylesheet" href="../styles.css?v=nav-wordmark-v1">
+    <link rel="stylesheet" href="../styles.css?v=nav-wordmark-v2">
   </head>
   <body>
     <a class="skip-link" href="#site-main">Skip to content</a>
@@ -47,8 +47,8 @@
             <span class="nav-wordmark-text">Göther Labs</span>
           </a>
           <div class="nav-links">
-            <a href="./">Company</a>
             <a href="../results/">Results</a>
+            <a href="./">Company</a>
             <a href="../contact/">Contact</a>
           </div>
         </nav>
@@ -131,6 +131,6 @@
       </footer>
     </div>
 
-    <script src="../scripts.js?v=nav-wordmark-v1"></script>
+    <script src="../scripts.js?v=nav-wordmark-v2"></script>
   </body>
 </html>

--- a/contact/index.html
+++ b/contact/index.html
@@ -21,7 +21,7 @@
     <meta name="twitter:image" content="https://www.gotherlabs.com/assets/og-image.png">
     <link rel="preload" href="/assets/fonts/inter-latin.woff2" as="font" type="font/woff2" crossorigin>
     <link rel="icon" href="../assets/gother-mark.svg" type="image/svg+xml">
-    <link rel="stylesheet" href="../styles.css?v=nav-wordmark-v1">
+    <link rel="stylesheet" href="../styles.css?v=nav-wordmark-v2">
   </head>
   <body>
     <a class="skip-link" href="#site-main">Skip to content</a>
@@ -47,8 +47,8 @@
             <span class="nav-wordmark-text">Göther Labs</span>
           </a>
           <div class="nav-links">
-            <a href="../company/">Company</a>
             <a href="../results/">Results</a>
+            <a href="../company/">Company</a>
             <a href="./">Contact</a>
           </div>
         </nav>
@@ -111,6 +111,6 @@
       </footer>
     </div>
 
-    <script src="../scripts.js?v=nav-wordmark-v1"></script>
+    <script src="../scripts.js?v=nav-wordmark-v2"></script>
   </body>
 </html>

--- a/docs/preview-qa.md
+++ b/docs/preview-qa.md
@@ -81,7 +81,7 @@ For each viewport, verify:
 
 When `tools/sync-results.mjs` or generated result files change:
 
-- Confirm generated pages keep `styles.css?v=nav-wordmark-v1` and `scripts.js?v=nav-wordmark-v1`.
+- Confirm generated pages keep `styles.css?v=nav-wordmark-v2` and `scripts.js?v=nav-wordmark-v2`.
 - Confirm generated pages use the current wordmark shell and `.nav-links` wrapper.
 - Confirm copied run pages keep their expected noindex behavior.
 - Confirm generated result diffs are limited to intended shell, metadata, or result-content changes.

--- a/docs/site-shell.md
+++ b/docs/site-shell.md
@@ -12,7 +12,7 @@ The shared shell includes:
 - Inter font preload.
 - Favicon.
 - Shared `styles.css` and `scripts.js` includes.
-- Shared shell cache-busting version, currently `nav-wordmark-v1`.
+- Shared shell cache-busting version, currently `nav-wordmark-v2`.
 - Canonical URL, Open Graph metadata, Twitter card metadata, and page-specific metadata exceptions.
 
 The hand-authored shell currently appears in:

--- a/evolther/index.html
+++ b/evolther/index.html
@@ -11,7 +11,7 @@
     <meta name="robots" content="noindex, nofollow">
     <link rel="preload" href="/assets/fonts/inter-latin.woff2" as="font" type="font/woff2" crossorigin>
     <link rel="icon" href="../assets/gother-mark.svg" type="image/svg+xml">
-    <link rel="stylesheet" href="../styles.css?v=nav-wordmark-v1">
+    <link rel="stylesheet" href="../styles.css?v=nav-wordmark-v2">
     <link rel="stylesheet" href="./page.css?v=evolther-responsive-v8">
   </head>
   <body class="evolther-2-page">
@@ -38,8 +38,8 @@
             <span class="nav-wordmark-text">Göther Labs</span>
           </a>
           <div class="nav-links">
-            <a href="../company/">Company</a>
             <a href="../results/">Results</a>
+            <a href="../company/">Company</a>
             <a href="../contact/">Contact</a>
           </div>
         </nav>
@@ -231,7 +231,7 @@
       </footer>
     </div>
 
-    <script src="../scripts.js?v=nav-wordmark-v1"></script>
+    <script src="../scripts.js?v=nav-wordmark-v2"></script>
     <script src="./page.js?v=evolther-mobile-order-v3"></script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -21,15 +21,15 @@
     <meta name="twitter:image" content="https://www.gotherlabs.com/assets/og-image.png">
     <link rel="preload" href="/assets/fonts/inter-latin.woff2" as="font" type="font/woff2" crossorigin>
     <link rel="icon" href="./assets/gother-mark.svg" type="image/svg+xml">
-    <link rel="stylesheet" href="./styles.css?v=nav-wordmark-v1">
+    <link rel="stylesheet" href="./styles.css?v=nav-wordmark-v2">
   </head>
   <body class="home-page">
     <a class="skip-link" href="#site-main">Skip to content</a>
     <div class="page-shell site-shell">
       <header class="site-header">
         <nav class="site-nav" aria-label="Primary">
-          <a href="./company/">Company</a>
           <a href="./results/">Results</a>
+          <a href="./company/">Company</a>
           <a href="./contact/">Contact</a>
         </nav>
       </header>
@@ -71,6 +71,6 @@
 
     </div>
 
-    <script src="./scripts.js?v=nav-wordmark-v1"></script>
+    <script src="./scripts.js?v=nav-wordmark-v2"></script>
   </body>
 </html>

--- a/results/circle-packing-26-unit-square/index.html
+++ b/results/circle-packing-26-unit-square/index.html
@@ -15,7 +15,7 @@
     <meta name="twitter:image" content="https://www.gotherlabs.com/assets/og-image.png">
     <link rel="preload" href="/assets/fonts/inter-latin.woff2" as="font" type="font/woff2" crossorigin>
     <link rel="icon" href="../../assets/gother-mark.svg" type="image/svg+xml">
-    <link rel="stylesheet" href="../../styles.css?v=nav-wordmark-v1">
+    <link rel="stylesheet" href="../../styles.css?v=nav-wordmark-v2">
     <script>
       window.MathJax = {
         tex: {
@@ -57,8 +57,8 @@
             <span class="nav-wordmark-text">Göther Labs</span>
           </a>
           <div class="nav-links">
-            <a href="../../company/">Company</a>
             <a href="../../results/">Results</a>
+            <a href="../../company/">Company</a>
             <a href="../../contact/">Contact</a>
           </div>
         </nav>
@@ -1481,6 +1481,6 @@ J(P) = -R(P).
       </footer>
     </div>
 
-    <script src="../../scripts.js?v=nav-wordmark-v1"></script>
+    <script src="../../scripts.js?v=nav-wordmark-v2"></script>
   </body>
 </html>

--- a/results/circle-packing-26-unit-square/run/index.html
+++ b/results/circle-packing-26-unit-square/run/index.html
@@ -8,7 +8,7 @@
     <meta name="robots" content="noindex, nofollow">
     <link rel="preload" href="/assets/fonts/inter-latin.woff2" as="font" type="font/woff2" crossorigin>
     <link rel="icon" href="../../../assets/gother-mark.svg" type="image/svg+xml">
-    <link rel="stylesheet" href="../../../styles.css?v=nav-wordmark-v1">
+    <link rel="stylesheet" href="../../../styles.css?v=nav-wordmark-v2">
     <link rel="stylesheet" href="./surface.css?v=circle-packing-v2">
   </head>
   <body class="packing-surface-page">
@@ -34,8 +34,8 @@
             <span class="nav-wordmark-text">Göther Labs</span>
           </a>
           <div class="nav-links">
-            <a href="../../../company/">Company</a>
             <a href="../../../results/">Results</a>
+            <a href="../../../company/">Company</a>
             <a href="../../../contact/">Contact</a>
           </div>
         </nav>
@@ -143,7 +143,7 @@
       </footer>
     </div>
 
-    <script src="../../../scripts.js?v=nav-wordmark-v1"></script>
+    <script src="../../../scripts.js?v=nav-wordmark-v2"></script>
     <script src="./surface-data.js"></script>
     <script src="./surface.js?v=circle-packing-v2"></script>
   </body>

--- a/results/index.html
+++ b/results/index.html
@@ -15,7 +15,7 @@
     <meta name="twitter:image" content="https://www.gotherlabs.com/assets/og-image.png">
     <link rel="preload" href="/assets/fonts/inter-latin.woff2" as="font" type="font/woff2" crossorigin>
     <link rel="icon" href="../assets/gother-mark.svg" type="image/svg+xml">
-    <link rel="stylesheet" href="../styles.css?v=nav-wordmark-v1">
+    <link rel="stylesheet" href="../styles.css?v=nav-wordmark-v2">
 
   </head>
   <body>
@@ -42,8 +42,8 @@
             <span class="nav-wordmark-text">Göther Labs</span>
           </a>
           <div class="nav-links">
-            <a href="../company/">Company</a>
             <a href="../results/">Results</a>
+            <a href="../company/">Company</a>
             <a href="../contact/">Contact</a>
           </div>
         </nav>
@@ -230,6 +230,6 @@
       </footer>
     </div>
 
-    <script src="../scripts.js?v=nav-wordmark-v1"></script>
+    <script src="../scripts.js?v=nav-wordmark-v2"></script>
   </body>
 </html>

--- a/results/quadrature-rule-optimization/index.html
+++ b/results/quadrature-rule-optimization/index.html
@@ -15,7 +15,7 @@
     <meta name="twitter:image" content="https://www.gotherlabs.com/assets/og-image.png">
     <link rel="preload" href="/assets/fonts/inter-latin.woff2" as="font" type="font/woff2" crossorigin>
     <link rel="icon" href="../../assets/gother-mark.svg" type="image/svg+xml">
-    <link rel="stylesheet" href="../../styles.css?v=nav-wordmark-v1">
+    <link rel="stylesheet" href="../../styles.css?v=nav-wordmark-v2">
     <script>
       window.MathJax = {
         tex: {
@@ -57,8 +57,8 @@
             <span class="nav-wordmark-text">Göther Labs</span>
           </a>
           <div class="nav-links">
-            <a href="../../company/">Company</a>
             <a href="../../results/">Results</a>
+            <a href="../../company/">Company</a>
             <a href="../../contact/">Contact</a>
           </div>
         </nav>
@@ -879,6 +879,6 @@ p=1.7.
       </footer>
     </div>
 
-    <script src="../../scripts.js?v=nav-wordmark-v1"></script>
+    <script src="../../scripts.js?v=nav-wordmark-v2"></script>
   </body>
 </html>

--- a/results/quadrature-rule-optimization/run/index.html
+++ b/results/quadrature-rule-optimization/run/index.html
@@ -11,7 +11,7 @@
     <meta name="robots" content="noindex, nofollow">
     <link rel="preload" href="/assets/fonts/inter-latin.woff2" as="font" type="font/woff2" crossorigin>
     <link rel="icon" href="../../../assets/gother-mark.svg" type="image/svg+xml">
-    <link rel="stylesheet" href="../../../styles.css?v=nav-wordmark-v1">
+    <link rel="stylesheet" href="../../../styles.css?v=nav-wordmark-v2">
     <link rel="stylesheet" href="./surface.css?v=quadrature-trace-v23">
   </head>
   <body class="quadrature-surface-page">
@@ -37,8 +37,8 @@
             <span class="nav-wordmark-text">Göther Labs</span>
           </a>
           <div class="nav-links">
-            <a href="../../../company/">Company</a>
             <a href="../../../results/">Results</a>
+            <a href="../../../company/">Company</a>
             <a href="../../../contact/">Contact</a>
           </div>
         </nav>
@@ -142,7 +142,7 @@
       </footer>
     </div>
 
-    <script src="../../../scripts.js?v=nav-wordmark-v1"></script>
+    <script src="../../../scripts.js?v=nav-wordmark-v2"></script>
     <script src="./surface-data.js"></script>
     <script src="./surface.js?v=quadrature-trace-v23"></script>
   </body>

--- a/results/rcpsp-psplib-j30/index.html
+++ b/results/rcpsp-psplib-j30/index.html
@@ -15,7 +15,7 @@
     <meta name="twitter:image" content="https://www.gotherlabs.com/assets/og-image.png">
     <link rel="preload" href="/assets/fonts/inter-latin.woff2" as="font" type="font/woff2" crossorigin>
     <link rel="icon" href="../../assets/gother-mark.svg" type="image/svg+xml">
-    <link rel="stylesheet" href="../../styles.css?v=nav-wordmark-v1">
+    <link rel="stylesheet" href="../../styles.css?v=nav-wordmark-v2">
     <script>
       window.MathJax = {
         tex: {
@@ -57,8 +57,8 @@
             <span class="nav-wordmark-text">Göther Labs</span>
           </a>
           <div class="nav-links">
-            <a href="../../company/">Company</a>
             <a href="../../results/">Results</a>
+            <a href="../../company/">Company</a>
             <a href="../../contact/">Contact</a>
           </div>
         </nav>
@@ -1089,6 +1089,6 @@ score = mean(g_k) + 0.35 \cdot p95(g_k) + feasibility\_penalty.
       </footer>
     </div>
 
-    <script src="../../scripts.js?v=nav-wordmark-v1"></script>
+    <script src="../../scripts.js?v=nav-wordmark-v2"></script>
   </body>
 </html>

--- a/results/rcpsp-psplib-j30/run/index.html
+++ b/results/rcpsp-psplib-j30/run/index.html
@@ -8,7 +8,7 @@
     <meta name="robots" content="noindex, nofollow">
     <link rel="preload" href="/assets/fonts/inter-latin.woff2" as="font" type="font/woff2" crossorigin>
     <link rel="icon" href="../../../assets/gother-mark.svg" type="image/svg+xml">
-    <link rel="stylesheet" href="../../../styles.css?v=nav-wordmark-v1">
+    <link rel="stylesheet" href="../../../styles.css?v=nav-wordmark-v2">
     <link rel="stylesheet" href="./surface.css?v=rcpsp-v44">
   </head>
   <body class="rcpsp-surface-page">
@@ -34,8 +34,8 @@
             <span class="nav-wordmark-text">Göther Labs</span>
           </a>
           <div class="nav-links">
-            <a href="../../../company/">Company</a>
             <a href="../../../results/">Results</a>
+            <a href="../../../company/">Company</a>
             <a href="../../../contact/">Contact</a>
           </div>
         </nav>
@@ -140,7 +140,7 @@
       </footer>
     </div>
 
-    <script src="../../../scripts.js?v=nav-wordmark-v1"></script>
+    <script src="../../../scripts.js?v=nav-wordmark-v2"></script>
     <script src="./surface-data.js"></script>
     <script src="./surface.js?v=rcpsp-v44"></script>
   </body>

--- a/styles.css
+++ b/styles.css
@@ -188,16 +188,16 @@ a {
 .site-nav .nav-home-wordmark {
   grid-column: 2;
   justify-self: center;
-  gap: 0.34rem;
-  font-size: clamp(1.08rem, 1.55vw, 1.34rem);
+  gap: 0.48rem;
+  font-size: clamp(1.34rem, 2vw, 1.68rem);
   font-weight: 600;
   letter-spacing: -0.04em;
   white-space: nowrap;
 }
 
 .site-nav .nav-home-wordmark .wordmark-mark-wrap {
-  width: 0.82em;
-  height: 0.82em;
+  width: 1.32em;
+  height: 1.32em;
 }
 
 .nav-links {
@@ -2994,7 +2994,7 @@ a {
   }
 
   .site-nav .nav-home-wordmark {
-    font-size: 1.08rem;
+    font-size: 1.16rem;
   }
 
   .nav-links {

--- a/tools/site-shell.mjs
+++ b/tools/site-shell.mjs
@@ -1,6 +1,6 @@
 // Shared primitives for generated shell output and shell validation.
 // Hand-authored HTML remains committed directly; keep this boundary small.
-export const SITE_SHELL_VERSION = "nav-wordmark-v1";
+export const SITE_SHELL_VERSION = "nav-wordmark-v2";
 
 export const SHARED_SITE_SHELL = Object.freeze({
   version: SITE_SHELL_VERSION,
@@ -9,8 +9,8 @@ export const SHARED_SITE_SHELL = Object.freeze({
   stylesheetPath: "styles.css",
   scriptPath: "scripts.js",
   navLinks: Object.freeze([
-    ["company/", "Company"],
     ["results/", "Results"],
+    ["company/", "Company"],
     ["contact/", "Contact"],
   ]),
 });


### PR DESCRIPTION
## Summary
- Reorders primary navigation to Results, Company, Contact.
- Scales the shared header wordmark and symbol proportionally so the animated mark is legible.
- Bumps the shared shell asset version to nav-wordmark-v2 across generated and static pages.

## Validation
- node --check tools/sync-results.mjs
- node tools/check-site-shell.mjs
- git diff --check
- Browser check on home, results, and circle packing run pages.