### PR TITLE
Docs: align preview QA nav order

### DIFF
--- a/docs/preview-qa.md
+++ b/docs/preview-qa.md
@@ -69,7 +69,7 @@ Review each affected route at:
 
 For each viewport, verify:
 
-- Header navigation is visible, aligned, and ordered `Company`, `Results`, `Contact`.
+- Header navigation is visible, aligned, and ordered `Results`, `Company`, `Contact`.
 - The animated wordmark appears with the expected colored symbol dots where the shared shell uses it.
 - Text does not wrap unexpectedly or overlap adjacent content.
 - There is no horizontal overflow.


### PR DESCRIPTION
## Why

The manual preview QA checklist described the header navigation order as `Company`, `Results`, `Contact`, while the shared site shell and rendered pages use `Results`, `Company`, `Contact`.

Closes #52

## What changed

- Updated the visual QA checklist to document the current shared navigation order.

## Why this approach

This is a documentation alignment fix. The shared shell already defines the expected order, and `tools/check-site-shell.mjs` passes against the current implementation.

## How to review

- Compare `docs/preview-qa.md` with `tools/site-shell.mjs`.
- Confirm the checklist now matches the rendered navigation.

## Validation

- `node tools/check-site-shell.mjs`
- `git diff --check`

## Testing

No runtime code changed.
