### PR TITLE
Add home last proof link

### DIFF
--- a/404.html
+++ b/404.html
@@ -8,7 +8,7 @@
     <meta name="robots" content="noindex">
     <link rel="preload" href="/assets/fonts/inter-latin.woff2" as="font" type="font/woff2" crossorigin>
     <link rel="icon" href="./assets/gother-mark.svg" type="image/svg+xml">
-    <link rel="stylesheet" href="./styles.css?v=nav-wordmark-v2">
+    <link rel="stylesheet" href="./styles.css?v=home-proof-inline-v2">
   </head>
   <body class="not-found-page">
     <a class="skip-link" href="#site-main">Skip to content</a>
@@ -73,6 +73,6 @@
       </main>
     </div>
 
-    <script src="./scripts.js?v=nav-wordmark-v2"></script>
+    <script src="./scripts.js?v=home-proof-inline-v2"></script>
   </body>
 </html>

--- a/company/index.html
+++ b/company/index.html
@@ -21,7 +21,7 @@
     <meta name="twitter:image" content="https://www.gotherlabs.com/assets/og-image.png">
     <link rel="preload" href="/assets/fonts/inter-latin.woff2" as="font" type="font/woff2" crossorigin>
     <link rel="icon" href="../assets/gother-mark.svg" type="image/svg+xml">
-    <link rel="stylesheet" href="../styles.css?v=nav-wordmark-v2">
+    <link rel="stylesheet" href="../styles.css?v=home-proof-inline-v2">
   </head>
   <body>
     <a class="skip-link" href="#site-main">Skip to content</a>
@@ -131,6 +131,6 @@
       </footer>
     </div>
 
-    <script src="../scripts.js?v=nav-wordmark-v2"></script>
+    <script src="../scripts.js?v=home-proof-inline-v2"></script>
   </body>
 </html>

--- a/contact/index.html
+++ b/contact/index.html
@@ -21,7 +21,7 @@
     <meta name="twitter:image" content="https://www.gotherlabs.com/assets/og-image.png">
     <link rel="preload" href="/assets/fonts/inter-latin.woff2" as="font" type="font/woff2" crossorigin>
     <link rel="icon" href="../assets/gother-mark.svg" type="image/svg+xml">
-    <link rel="stylesheet" href="../styles.css?v=nav-wordmark-v2">
+    <link rel="stylesheet" href="../styles.css?v=home-proof-inline-v2">
   </head>
   <body>
     <a class="skip-link" href="#site-main">Skip to content</a>
@@ -111,6 +111,6 @@
       </footer>
     </div>
 
-    <script src="../scripts.js?v=nav-wordmark-v2"></script>
+    <script src="../scripts.js?v=home-proof-inline-v2"></script>
   </body>
 </html>

--- a/docs/preview-qa.md
+++ b/docs/preview-qa.md
@@ -81,7 +81,7 @@ For each viewport, verify:
 
 When `tools/sync-results.mjs` or generated result files change:
 
-- Confirm generated pages keep `styles.css?v=nav-wordmark-v2` and `scripts.js?v=nav-wordmark-v2`.
+- Confirm generated pages keep `styles.css?v=home-proof-inline-v2` and `scripts.js?v=home-proof-inline-v2`.
 - Confirm generated pages use the current wordmark shell and `.nav-links` wrapper.
 - Confirm copied run pages keep their expected noindex behavior.
 - Confirm generated result diffs are limited to intended shell, metadata, or result-content changes.

--- a/docs/site-shell.md
+++ b/docs/site-shell.md
@@ -12,7 +12,7 @@ The shared shell includes:
 - Inter font preload.
 - Favicon.
 - Shared `styles.css` and `scripts.js` includes.
-- Shared shell cache-busting version, currently `nav-wordmark-v2`.
+- Shared shell cache-busting version, currently `home-proof-inline-v2`.
 - Canonical URL, Open Graph metadata, Twitter card metadata, and page-specific metadata exceptions.
 
 The hand-authored shell currently appears in:

--- a/evolther/index.html
+++ b/evolther/index.html
@@ -11,7 +11,7 @@
     <meta name="robots" content="noindex, nofollow">
     <link rel="preload" href="/assets/fonts/inter-latin.woff2" as="font" type="font/woff2" crossorigin>
     <link rel="icon" href="../assets/gother-mark.svg" type="image/svg+xml">
-    <link rel="stylesheet" href="../styles.css?v=nav-wordmark-v2">
+    <link rel="stylesheet" href="../styles.css?v=home-proof-inline-v2">
     <link rel="stylesheet" href="./page.css?v=evolther-responsive-v8">
   </head>
   <body class="evolther-2-page">
@@ -231,7 +231,7 @@
       </footer>
     </div>
 
-    <script src="../scripts.js?v=nav-wordmark-v2"></script>
+    <script src="../scripts.js?v=home-proof-inline-v2"></script>
     <script src="./page.js?v=evolther-mobile-order-v3"></script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
     <meta name="twitter:image" content="https://www.gotherlabs.com/assets/og-image.png">
     <link rel="preload" href="/assets/fonts/inter-latin.woff2" as="font" type="font/woff2" crossorigin>
     <link rel="icon" href="./assets/gother-mark.svg" type="image/svg+xml">
-    <link rel="stylesheet" href="./styles.css?v=nav-wordmark-v2">
+    <link rel="stylesheet" href="./styles.css?v=home-proof-inline-v2">
   </head>
   <body class="home-page">
     <a class="skip-link" href="#site-main">Skip to content</a>
@@ -64,6 +64,10 @@
           <div class="home-intro" aria-label="Göther Labs positioning">
             <p>AI R&amp;D for governed optimization.</p>
             <p>Algorithmic Discovery, Evaluation-driven optimization.</p>
+            <a class="home-proof-phrase" href="./results/circle-packing-26-unit-square/run/">
+              Last proof:
+              <span>26-circle packing validates 2.635977 total radius</span>
+            </a>
           </div>
         </section>
 
@@ -71,6 +75,6 @@
 
     </div>
 
-    <script src="./scripts.js?v=nav-wordmark-v2"></script>
+    <script src="./scripts.js?v=home-proof-inline-v2"></script>
   </body>
 </html>

--- a/results/circle-packing-26-unit-square/index.html
+++ b/results/circle-packing-26-unit-square/index.html
@@ -15,7 +15,7 @@
     <meta name="twitter:image" content="https://www.gotherlabs.com/assets/og-image.png">
     <link rel="preload" href="/assets/fonts/inter-latin.woff2" as="font" type="font/woff2" crossorigin>
     <link rel="icon" href="../../assets/gother-mark.svg" type="image/svg+xml">
-    <link rel="stylesheet" href="../../styles.css?v=nav-wordmark-v2">
+    <link rel="stylesheet" href="../../styles.css?v=home-proof-inline-v2">
     <script>
       window.MathJax = {
         tex: {
@@ -1481,6 +1481,6 @@ J(P) = -R(P).
       </footer>
     </div>
 
-    <script src="../../scripts.js?v=nav-wordmark-v2"></script>
+    <script src="../../scripts.js?v=home-proof-inline-v2"></script>
   </body>
 </html>

--- a/results/circle-packing-26-unit-square/run/index.html
+++ b/results/circle-packing-26-unit-square/run/index.html
@@ -8,7 +8,7 @@
     <meta name="robots" content="noindex, nofollow">
     <link rel="preload" href="/assets/fonts/inter-latin.woff2" as="font" type="font/woff2" crossorigin>
     <link rel="icon" href="../../../assets/gother-mark.svg" type="image/svg+xml">
-    <link rel="stylesheet" href="../../../styles.css?v=nav-wordmark-v2">
+    <link rel="stylesheet" href="../../../styles.css?v=home-proof-inline-v2">
     <link rel="stylesheet" href="./surface.css?v=circle-packing-v2">
   </head>
   <body class="packing-surface-page">
@@ -143,7 +143,7 @@
       </footer>
     </div>
 
-    <script src="../../../scripts.js?v=nav-wordmark-v2"></script>
+    <script src="../../../scripts.js?v=home-proof-inline-v2"></script>
     <script src="./surface-data.js"></script>
     <script src="./surface.js?v=circle-packing-v2"></script>
   </body>

--- a/results/index.html
+++ b/results/index.html
@@ -15,7 +15,7 @@
     <meta name="twitter:image" content="https://www.gotherlabs.com/assets/og-image.png">
     <link rel="preload" href="/assets/fonts/inter-latin.woff2" as="font" type="font/woff2" crossorigin>
     <link rel="icon" href="../assets/gother-mark.svg" type="image/svg+xml">
-    <link rel="stylesheet" href="../styles.css?v=nav-wordmark-v2">
+    <link rel="stylesheet" href="../styles.css?v=home-proof-inline-v2">
 
   </head>
   <body>
@@ -230,6 +230,6 @@
       </footer>
     </div>
 
-    <script src="../scripts.js?v=nav-wordmark-v2"></script>
+    <script src="../scripts.js?v=home-proof-inline-v2"></script>
   </body>
 </html>

--- a/results/quadrature-rule-optimization/index.html
+++ b/results/quadrature-rule-optimization/index.html
@@ -15,7 +15,7 @@
     <meta name="twitter:image" content="https://www.gotherlabs.com/assets/og-image.png">
     <link rel="preload" href="/assets/fonts/inter-latin.woff2" as="font" type="font/woff2" crossorigin>
     <link rel="icon" href="../../assets/gother-mark.svg" type="image/svg+xml">
-    <link rel="stylesheet" href="../../styles.css?v=nav-wordmark-v2">
+    <link rel="stylesheet" href="../../styles.css?v=home-proof-inline-v2">
     <script>
       window.MathJax = {
         tex: {
@@ -879,6 +879,6 @@ p=1.7.
       </footer>
     </div>
 
-    <script src="../../scripts.js?v=nav-wordmark-v2"></script>
+    <script src="../../scripts.js?v=home-proof-inline-v2"></script>
   </body>
 </html>

--- a/results/quadrature-rule-optimization/run/index.html
+++ b/results/quadrature-rule-optimization/run/index.html
@@ -11,7 +11,7 @@
     <meta name="robots" content="noindex, nofollow">
     <link rel="preload" href="/assets/fonts/inter-latin.woff2" as="font" type="font/woff2" crossorigin>
     <link rel="icon" href="../../../assets/gother-mark.svg" type="image/svg+xml">
-    <link rel="stylesheet" href="../../../styles.css?v=nav-wordmark-v2">
+    <link rel="stylesheet" href="../../../styles.css?v=home-proof-inline-v2">
     <link rel="stylesheet" href="./surface.css?v=quadrature-trace-v23">
   </head>
   <body class="quadrature-surface-page">
@@ -142,7 +142,7 @@
       </footer>
     </div>
 
-    <script src="../../../scripts.js?v=nav-wordmark-v2"></script>
+    <script src="../../../scripts.js?v=home-proof-inline-v2"></script>
     <script src="./surface-data.js"></script>
     <script src="./surface.js?v=quadrature-trace-v23"></script>
   </body>

--- a/results/rcpsp-psplib-j30/index.html
+++ b/results/rcpsp-psplib-j30/index.html
@@ -15,7 +15,7 @@
     <meta name="twitter:image" content="https://www.gotherlabs.com/assets/og-image.png">
     <link rel="preload" href="/assets/fonts/inter-latin.woff2" as="font" type="font/woff2" crossorigin>
     <link rel="icon" href="../../assets/gother-mark.svg" type="image/svg+xml">
-    <link rel="stylesheet" href="../../styles.css?v=nav-wordmark-v2">
+    <link rel="stylesheet" href="../../styles.css?v=home-proof-inline-v2">
     <script>
       window.MathJax = {
         tex: {
@@ -1089,6 +1089,6 @@ score = mean(g_k) + 0.35 \cdot p95(g_k) + feasibility\_penalty.
       </footer>
     </div>
 
-    <script src="../../scripts.js?v=nav-wordmark-v2"></script>
+    <script src="../../scripts.js?v=home-proof-inline-v2"></script>
   </body>
 </html>

--- a/results/rcpsp-psplib-j30/run/index.html
+++ b/results/rcpsp-psplib-j30/run/index.html
@@ -8,7 +8,7 @@
     <meta name="robots" content="noindex, nofollow">
     <link rel="preload" href="/assets/fonts/inter-latin.woff2" as="font" type="font/woff2" crossorigin>
     <link rel="icon" href="../../../assets/gother-mark.svg" type="image/svg+xml">
-    <link rel="stylesheet" href="../../../styles.css?v=nav-wordmark-v2">
+    <link rel="stylesheet" href="../../../styles.css?v=home-proof-inline-v2">
     <link rel="stylesheet" href="./surface.css?v=rcpsp-v44">
   </head>
   <body class="rcpsp-surface-page">
@@ -140,7 +140,7 @@
       </footer>
     </div>
 
-    <script src="../../../scripts.js?v=nav-wordmark-v2"></script>
+    <script src="../../../scripts.js?v=home-proof-inline-v2"></script>
     <script src="./surface-data.js"></script>
     <script src="./surface.js?v=rcpsp-v44"></script>
   </body>

--- a/styles.css
+++ b/styles.css
@@ -430,6 +430,34 @@ a {
   font-size: 0.98rem;
 }
 
+.home-proof-phrase {
+  display: inline-flex;
+  gap: 0.35rem;
+  position: fixed;
+  left: 50%;
+  bottom: clamp(1.6rem, 4dvh, 3rem);
+  z-index: 15;
+  max-width: calc(100vw - (var(--content-gutter) * 2));
+  transform: translateX(-50%);
+  color: var(--muted-soft);
+  font-size: 0.92rem;
+  font-weight: 300;
+  line-height: 1.45;
+  letter-spacing: -0.01em;
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.home-proof-phrase span {
+  color: var(--accent);
+  font-weight: 500;
+}
+
+.home-proof-phrase:hover span,
+.home-proof-phrase:focus-visible span {
+  color: var(--text);
+}
+
 .home-thesis-section {
   padding: 0 var(--content-gutter) clamp(4.8rem, 8vw, 7rem);
 }
@@ -3069,6 +3097,13 @@ a {
   .home-hero {
     width: 100%;
     padding: 0.65rem 0 clamp(20rem, 38dvh, 26rem);
+  }
+
+  .home-proof-phrase {
+    display: inline-block;
+    max-width: 28ch;
+    text-align: center;
+    white-space: normal;
   }
 
   .home-thesis-section {

--- a/tools/site-shell.mjs
+++ b/tools/site-shell.mjs
@@ -1,6 +1,6 @@
 // Shared primitives for generated shell output and shell validation.
 // Hand-authored HTML remains committed directly; keep this boundary small.
-export const SITE_SHELL_VERSION = "nav-wordmark-v2";
+export const SITE_SHELL_VERSION = "home-proof-inline-v2";
 
 export const SHARED_SITE_SHELL = Object.freeze({
   version: SITE_SHELL_VERSION,


### PR DESCRIPTION
Why
- The home page should surface the strongest current proof without requiring scroll or a large content block.
- The 26-circle packing replay is the clearest visual proof because it links a concrete metric to an animated artifact.

What changed
- Added a compact fixed-bottom "Last proof" phrase to the home hero.
- Linked the phrase directly to the 26-circle packing run replay.
- Highlighted the validated total radius in accent blue.
- Bumped the shared site shell asset version to home-proof-inline-v2.

Why this approach
- Keeps the first viewport minimal while giving visitors an immediate proof point.
- Avoids reintroducing the previous scroll narrative or a large bottom section.

How to review
- Open the home page and confirm the proof phrase appears at the bottom of the first viewport.
- Click the phrase and confirm it opens the 26-circle packing replay.
- Check desktop and mobile widths for wrapping and overflow.

Validation
- node tools/check-site-shell.mjs
- git diff --check
- Playwright desktop/mobile viewport checks: visible in first viewport, no horizontal overflow, no console errors.

Testing
- No runtime application tests were added; this is a static home page presentation change.