### PR TITLE
Polish qubit routing result presentation

### DIFF
--- a/results/index.html
+++ b/results/index.html
@@ -15,7 +15,7 @@
     <meta name="twitter:image" content="https://www.gotherlabs.com/assets/og-image.png">
     <link rel="preload" href="/assets/fonts/inter-latin.woff2" as="font" type="font/woff2" crossorigin>
     <link rel="icon" href="../assets/gother-mark.svg" type="image/svg+xml">
-    <link rel="stylesheet" href="../styles.css?v=home-proof-inline-v2">
+    <link rel="stylesheet" href="../styles.css?v=home-proof-inline-v3">
 
   </head>
   <body>
@@ -225,33 +225,28 @@
 
 <article class="result-card result-card--qubit-routing">
             <a class="result-link" href="./qubit-routing-lightsabre/" aria-label="Read Qubit routing LightSABRE benchmark">
-              <svg class="result-card-visual result-card-visual--qubit-routing" viewBox="0 0 560 360" aria-hidden="true" focusable="false">
-                <g class="result-card-qubit-circuit">
-                  <path class="qc-wire" d="M78 88H492M78 126H492M78 164H492M78 202H492M78 240H492M78 278H492" />
+              <svg class="result-card-visual result-card-visual--qubit-routing" viewBox="0 0 560 310" aria-hidden="true" focusable="false">
+                <g class="result-card-qubit-circuit" transform="translate(0 16)">
+                  <path class="qc-wire" d="M58 74H520M58 118H520M58 162H520M58 206H520M58 250H520" />
                   <g class="qc-muted">
-                    <path class="qc-link" d="M124 88V164" />
-                    <circle class="qc-control" cx="124" cy="88" r="5" />
-                    <circle class="qc-target" cx="124" cy="164" r="14" />
-                    <path class="qc-plus" d="M112 164H136M124 152V176" />
-                    <path class="qc-link" d="M206 126V240" />
-                    <circle class="qc-control" cx="206" cy="126" r="5" />
-                    <circle class="qc-target" cx="206" cy="240" r="14" />
-                    <path class="qc-plus" d="M194 240H218M206 228V252" />
-                    <path class="qc-link" d="M392 88V202" />
-                    <circle class="qc-control" cx="392" cy="88" r="5" />
-                    <circle class="qc-target" cx="392" cy="202" r="14" />
-                    <path class="qc-plus" d="M380 202H404M392 190V214" />
+                    <path class="qc-link" d="M116 74V162" />
+                    <circle class="qc-control" cx="116" cy="74" r="5" />
+                    <circle class="qc-target" cx="116" cy="162" r="15" />
+                    <path class="qc-plus" d="M103 162H129M116 149V175" />
+                    <path class="qc-link" d="M216 118V250" />
+                    <circle class="qc-control" cx="216" cy="118" r="5" />
+                    <circle class="qc-target" cx="216" cy="250" r="15" />
+                    <path class="qc-plus" d="M203 250H229M216 237V263" />
+                    <path class="qc-link" d="M440 74V206" />
+                    <circle class="qc-control" cx="440" cy="74" r="5" />
+                    <circle class="qc-target" cx="440" cy="206" r="15" />
+                    <path class="qc-plus" d="M427 206H453M440 193V219" />
                   </g>
                   <g class="qc-active">
-                    <path class="qc-link" d="M278 164V202" />
-                    <path class="qc-swap" d="M266 152L290 176M290 152L266 176M266 190L290 214M290 190L266 214" />
-                    <path class="qc-link" d="M326 202V240" />
-                    <path class="qc-swap" d="M314 190L338 214M338 190L314 214M314 228L338 252M338 228L314 252" />
-                  </g>
-                  <g class="qc-readout">
-                    <path class="qc-axis" d="M98 320H462" />
-                    <rect class="qc-reference" x="98" y="298" width="304" height="14" />
-                    <rect class="qc-accepted" x="98" y="274" width="268" height="14" />
+                    <path class="qc-link" d="M314 162V206" />
+                    <path class="qc-swap" d="M301 149L327 175M327 149L301 175M301 193L327 219M327 193L301 219" />
+                    <path class="qc-link" d="M366 206V250" />
+                    <path class="qc-swap" d="M353 193L379 219M379 193L353 219M353 237L379 263M379 237L353 263" />
                   </g>
                 </g>
               </svg>
@@ -263,8 +258,8 @@
               <div class="result-measure">
                 <span>Added CNOT reduction</span>
                 <strong>12,294 fewer</strong>
-                <span>Replay validity</span>
-                <strong>72 / 72 cases</strong>
+                <span>Q20 CNOT reduction</span>
+                <strong>17.39%</strong>
               </div>
             </a>
           </article>

--- a/results/qubit-routing-lightsabre/index.html
+++ b/results/qubit-routing-lightsabre/index.html
@@ -73,8 +73,8 @@
         <section class="result-detail result-whitepaper-shell qubit-routing-whitepaper-shell">
           <article class="result-article result-whitepaper qubit-routing-whitepaper">
 <h3>Abstract</h3>
-<p>This note reports a deterministic qubit-routing policy for a frozen 24-circuit swap-reduction benchmark, a public scoring trace, and an exact replay candidate. The accepted policy reduces added CNOTs versus LightSABRE while preserving replay validity on the fixed public portfolio. The report exposes the scoring chain, the routing-policy surface, and the topology split together instead of compressing the result into a single aggregate number.</p>
-<p>For audit clarity, the public claim is not a universal quantum compiler result and not a runtime benchmark. It is the combination of the accepted Rust policy surface, the replayed scoring evidence, and the evaluator-validated routing readout on one frozen 24-circuit portfolio. The report keeps the candidate, scoring contract, replay confirmation, and topology split exposed together instead of compressing the result into only the aggregate score.</p>
+<p>This note reports a deterministic qubit-routing policy, a public scoring trace, and an exact replay candidate for a frozen swap-reduction benchmark. The accepted policy reduces added CNOTs by 12,294 versus LightSABRE while keeping the routing-policy surface and topology split visible.</p>
+<p>The claim is deliberately bounded: it is not a universal quantum compiler result, not a runtime benchmark, and not a hardware-performance claim.</p>
 <h3>1. Problem formulation</h3>
 <p>The two-qubit gate that matters in this benchmark is the CNOT. A CNOT flips the target qubit only when the control qubit is 1; together with arbitrary one-qubit gates, CNOT is a standard building block for universal quantum circuits. Hardware routing matters because a SWAP between adjacent physical qubits is normally decomposed into three CNOTs, so every extra SWAP directly inflates the added-CNOT readout.</p>
 <figure class="result-primer-card result-paper-figure qubit-routing-inline-figure qubit-gate-primer-figure" id="fig-1">
@@ -688,6 +688,12 @@ J(p) = -\Delta_{\mathrm{wCNOT}}(p),
                   <td>295,782</td>
                   <td>12,294 fewer</td>
                 </tr>
+                <tr>
+                  <td>Case outcome</td>
+                  <td>reference</td>
+                  <td>31 / 6 / 35</td>
+                  <td>wins / ties / losses</td>
+                </tr>
               </tbody>
             </table>
           </div>
@@ -745,47 +751,61 @@ J(p) = -\Delta_{\mathrm{wCNOT}}(p),
           <figcaption>Figure 5. Per-topology added-CNOT comparison. Grey bars are LightSABRE, blue overlays are the accepted replay, and shorter bars mean fewer added CNOTs. Q20 improves strongly, Willow improves modestly, and Heron-FEZ is slightly worse on aggregate.</figcaption>
         </figure>
 <figure class="result-primer-card result-paper-figure qubit-routing-inline-figure qubit-routing-readout-figure" id="fig-6">
-          <svg class="result-primer-svg qubit-routing-paper-svg" viewBox="0 0 560 232" role="img" aria-label="Case-level replay sample for accepted qubit routing candidate.">
-            <text class="result-axis-label result-figure-title" x="72" y="34">Case-level replay sample</text>
-            <path class="qubit-routing-divider" d="M72 72H488" />
-            <text class="qubit-routing-note" x="72" y="84">sample case</text>
-            <text class="qubit-routing-note" x="354" y="84" text-anchor="end">accepted</text>
-            <text class="qubit-routing-note" x="488" y="84" text-anchor="end">vs LightSABRE</text>
+          <svg class="result-primer-svg qubit-routing-paper-svg" viewBox="0 0 560 260" role="img" aria-label="Selected case-level replay examples comparing accepted routing with LightSABRE.">
+            <text class="result-axis-label result-figure-title" x="52" y="34">Selected largest case savings</text>
+            <path class="qubit-routing-divider" d="M52 72H520" />
+            <text class="qubit-routing-note" x="52" y="86">sample case</text>
+            <text class="qubit-routing-note" x="278" y="86" text-anchor="end">accepted</text>
+            <text class="qubit-routing-note" x="386" y="86" text-anchor="end">LightSABRE</text>
+            <text class="qubit-routing-note" x="458" y="86" text-anchor="end">saved</text>
+            <text class="qubit-routing-note" x="520" y="86" text-anchor="end">%</text>
+            <path class="qubit-routing-divider qubit-routing-divider--soft" d="M52 98H520" />
 <g>
-              <text class="qubit-routing-note" x="72" y="100">9symml_195_q20</text>
-              <text class="qubit-routing-value" x="354" y="100" text-anchor="end">12,057</text>
-              <text class="qubit-routing-value" x="488" y="100" text-anchor="end">-3,792</text>
+              <text class="qubit-routing-note" x="52" y="116">9symml_195_q20</text>
+              <text class="qubit-routing-value" x="278" y="116" text-anchor="end">12,057</text>
+              <text class="qubit-routing-value" x="386" y="116" text-anchor="end">15,849</text>
+              <text class="qubit-routing-value" x="458" y="116" text-anchor="end">3,792</text>
+              <text class="qubit-routing-value" x="520" y="116" text-anchor="end">23.93%</text>
             </g>
 <g>
-              <text class="qubit-routing-note" x="72" y="124">sym9_193_q20</text>
-              <text class="qubit-routing-value" x="354" y="124" text-anchor="end">12,057</text>
-              <text class="qubit-routing-value" x="488" y="124" text-anchor="end">-3,792</text>
+              <text class="qubit-routing-note" x="52" y="142">sym9_193_q20</text>
+              <text class="qubit-routing-value" x="278" y="142" text-anchor="end">12,057</text>
+              <text class="qubit-routing-value" x="386" y="142" text-anchor="end">15,849</text>
+              <text class="qubit-routing-value" x="458" y="142" text-anchor="end">3,792</text>
+              <text class="qubit-routing-value" x="520" y="142" text-anchor="end">23.93%</text>
             </g>
 <g>
-              <text class="qubit-routing-note" x="72" y="148">9symml_195_willow</text>
-              <text class="qubit-routing-value" x="354" y="148" text-anchor="end">25,155</text>
-              <text class="qubit-routing-value" x="488" y="148" text-anchor="end">-903</text>
+              <text class="qubit-routing-note" x="52" y="168">9symml_195_willow</text>
+              <text class="qubit-routing-value" x="278" y="168" text-anchor="end">25,155</text>
+              <text class="qubit-routing-value" x="386" y="168" text-anchor="end">26,058</text>
+              <text class="qubit-routing-value" x="458" y="168" text-anchor="end">903</text>
+              <text class="qubit-routing-value" x="520" y="168" text-anchor="end">3.47%</text>
             </g>
 <g>
-              <text class="qubit-routing-note" x="72" y="172">sym9_193_willow</text>
-              <text class="qubit-routing-value" x="354" y="172" text-anchor="end">25,155</text>
-              <text class="qubit-routing-value" x="488" y="172" text-anchor="end">-903</text>
+              <text class="qubit-routing-note" x="52" y="194">sym9_193_willow</text>
+              <text class="qubit-routing-value" x="278" y="194" text-anchor="end">25,155</text>
+              <text class="qubit-routing-value" x="386" y="194" text-anchor="end">26,058</text>
+              <text class="qubit-routing-value" x="458" y="194" text-anchor="end">903</text>
+              <text class="qubit-routing-value" x="520" y="194" text-anchor="end">3.47%</text>
             </g>
 <g>
-              <text class="qubit-routing-note" x="72" y="196">rd84_253_q20</text>
-              <text class="qubit-routing-value" x="354" y="196" text-anchor="end">4,884</text>
-              <text class="qubit-routing-value" x="488" y="196" text-anchor="end">-615</text>
+              <text class="qubit-routing-note" x="52" y="220">rd84_253_q20</text>
+              <text class="qubit-routing-value" x="278" y="220" text-anchor="end">4,884</text>
+              <text class="qubit-routing-value" x="386" y="220" text-anchor="end">5,499</text>
+              <text class="qubit-routing-value" x="458" y="220" text-anchor="end">615</text>
+              <text class="qubit-routing-value" x="520" y="220" text-anchor="end">11.18%</text>
             </g>
           </svg>
-          <figcaption>Figure 6. Accepted replay sample. These rows are a case-level diagnostic, not a second aggregate readout.</figcaption>
+          <figcaption>Figure 6. Selected largest case-level savings from the replay export. The rows are sorted by absolute CNOT reduction versus LightSABRE; the final column gives the same reduction as a percentage of the LightSABRE case.</figcaption>
         </figure>
-<p>The result is not uniform across topology families. Q20 carries the largest positive readout, Willow is modestly positive, and Heron-FEZ is slightly worse than LightSABRE on aggregate. The public result keeps that split visible instead of compressing it into only the all-portfolio score.</p>
+<p>The result is not uniform across topology families: Q20 carries the largest positive readout, Willow is modestly positive, and Heron-FEZ is slightly worse than LightSABRE on aggregate. Across individual cases the accepted policy records 31 wins, 6 ties, and 35 losses; Figure 6 highlights the largest positive case savings rather than the full case distribution.</p>
 <h3>5. Limitations</h3>
 <p>This report is limited to the frozen 24-circuit LightSABRE portfolio in the bundle. It does not claim improvement on arbitrary circuits, arbitrary hardware topologies, all related benchmark assets, or production compiler workloads.</p>
 <p>The benchmark measures routing quality through added CNOT count. It does not make a wall-clock speed claim, does not measure hardware execution fidelity, and does not evaluate downstream transpiler passes after routing.</p>
 <h3>6. Reproducibility</h3>
 <p>The public bundle includes the accepted Rust candidate, the evaluation contract, metrics, a curated evolution chain, replay confirmation, public figures, and a curated animated replay at <a href="./run/">the run page</a>. The replay excludes prompts, raw telemetry, local logs, private paths, and operational run state.</p>
-<p>The accepted candidate id is <code>gen-62-i0-w3-a0-8185f10d0dff4245</code>. The replay score matched the recorded score exactly at <code>-11506.200000000026</code> under the public score-tolerance policy.</p>
+<p>Replaying the result should use the same 24-circuit LightSABRE portfolio, the same Q20, Willow, and Heron-FEZ coupling graphs, the same added-CNOT objective, the same case weights, and the same lower-is-better governed score. Changing the topology set, case set, routing objective, or LightSABRE reference creates a new evaluation, not a replay of this result.</p>
+<p>Under that replay contract, the accepted Rust candidate reproduces 295,782 aggregate added CNOTs, 12,294 fewer than the LightSABRE reference, with a 31 / 6 / 35 win/tie/loss case split.</p>
 <p>The source bundle is available in <a href="https://github.com/Gother-Labs/gother-labs-results/tree/main/results" target="_blank" rel="noreferrer">Göther Labs results repository</a>.</p>
           </article>
         </section>

--- a/styles.css
+++ b/styles.css
@@ -1113,9 +1113,9 @@ a {
 }
 
 .result-card--qubit-routing .result-card-visual {
-  right: clamp(-6rem, -4vw, -1.4rem);
-  bottom: clamp(0.6rem, 1.8vw, 1.8rem);
-  width: min(66%, 39rem);
+  right: clamp(-8rem, -5.5vw, -2.6rem);
+  bottom: clamp(1.4rem, 2.4vw, 2.8rem);
+  width: min(70%, 42rem);
 }
 
 .result-card-qubit-routing path,
@@ -1206,20 +1206,6 @@ a {
 .result-card-qubit-circuit .qc-active .qc-swap {
   stroke: var(--accent);
   stroke-width: 3;
-}
-
-.result-card-qubit-circuit .qc-axis {
-  fill: none;
-  stroke: color-mix(in srgb, var(--text) 50%, transparent);
-  stroke-width: 1.2;
-}
-
-.result-card-qubit-circuit .qc-reference {
-  fill: color-mix(in srgb, var(--text) 18%, transparent);
-}
-
-.result-card-qubit-circuit .qc-accepted {
-  fill: color-mix(in srgb, var(--accent) 72%, transparent);
 }
 
 .result-card-packing rect,
@@ -1321,8 +1307,9 @@ a {
   }
 
   .result-card--qubit-routing .result-card-visual {
-    right: 0.8rem;
-    width: min(52%, 28rem);
+    right: clamp(-3rem, -5vw, -1.2rem);
+    bottom: 0.35rem;
+    width: min(58%, 31rem);
   }
 }
 
@@ -2654,6 +2641,11 @@ a {
   stroke-linecap: round;
   stroke-linejoin: round;
   stroke-width: 1.6;
+}
+
+.qubit-routing-paper-svg .qubit-routing-divider--soft {
+  stroke: color-mix(in srgb, var(--text) 24%, transparent);
+  stroke-width: 1;
 }
 
 .qubit-routing-paper-svg .qubit-routing-transfer {

--- a/tools/sync-results.mjs
+++ b/tools/sync-results.mjs
@@ -242,6 +242,22 @@ ${body}
 }
 
 function resultCardMeasureItems(result) {
+  if (result.slug === "qubit-routing-lightsabre") {
+    return [
+      [
+        "Added CNOT reduction",
+        `${formatMetric(result.metrics?.added_cnot_reduction_vs_lightsabre, { maximumFractionDigits: 0 })} fewer`,
+      ],
+      [
+        "Q20 CNOT reduction",
+        `${formatMetric(result.metrics?.q20_relative_improvement_pct, {
+          maximumFractionDigits: 2,
+          minimumFractionDigits: 2,
+        })}%`,
+      ],
+    ];
+  }
+
   if (Array.isArray(result.website?.card_metrics) && result.website.card_metrics.length > 0) {
     return result.website.card_metrics.slice(0, 2).map((metric) => [
       metric.label,
@@ -354,33 +370,28 @@ ${circles.map(([cx, cy, r]) => `                  <circle cx="${cx}" cy="${cy}" 
   }
 
   if (result.website?.card_visual === "qubit-routing") {
-    return `<svg class="result-card-visual result-card-visual--qubit-routing" viewBox="0 0 560 360" aria-hidden="true" focusable="false">
-                <g class="result-card-qubit-circuit">
-                  <path class="qc-wire" d="M78 88H492M78 126H492M78 164H492M78 202H492M78 240H492M78 278H492" />
+    return `<svg class="result-card-visual result-card-visual--qubit-routing" viewBox="0 0 560 310" aria-hidden="true" focusable="false">
+                <g class="result-card-qubit-circuit" transform="translate(0 16)">
+                  <path class="qc-wire" d="M58 74H520M58 118H520M58 162H520M58 206H520M58 250H520" />
                   <g class="qc-muted">
-                    <path class="qc-link" d="M124 88V164" />
-                    <circle class="qc-control" cx="124" cy="88" r="5" />
-                    <circle class="qc-target" cx="124" cy="164" r="14" />
-                    <path class="qc-plus" d="M112 164H136M124 152V176" />
-                    <path class="qc-link" d="M206 126V240" />
-                    <circle class="qc-control" cx="206" cy="126" r="5" />
-                    <circle class="qc-target" cx="206" cy="240" r="14" />
-                    <path class="qc-plus" d="M194 240H218M206 228V252" />
-                    <path class="qc-link" d="M392 88V202" />
-                    <circle class="qc-control" cx="392" cy="88" r="5" />
-                    <circle class="qc-target" cx="392" cy="202" r="14" />
-                    <path class="qc-plus" d="M380 202H404M392 190V214" />
+                    <path class="qc-link" d="M116 74V162" />
+                    <circle class="qc-control" cx="116" cy="74" r="5" />
+                    <circle class="qc-target" cx="116" cy="162" r="15" />
+                    <path class="qc-plus" d="M103 162H129M116 149V175" />
+                    <path class="qc-link" d="M216 118V250" />
+                    <circle class="qc-control" cx="216" cy="118" r="5" />
+                    <circle class="qc-target" cx="216" cy="250" r="15" />
+                    <path class="qc-plus" d="M203 250H229M216 237V263" />
+                    <path class="qc-link" d="M440 74V206" />
+                    <circle class="qc-control" cx="440" cy="74" r="5" />
+                    <circle class="qc-target" cx="440" cy="206" r="15" />
+                    <path class="qc-plus" d="M427 206H453M440 193V219" />
                   </g>
                   <g class="qc-active">
-                    <path class="qc-link" d="M278 164V202" />
-                    <path class="qc-swap" d="M266 152L290 176M290 152L266 176M266 190L290 214M290 190L266 214" />
-                    <path class="qc-link" d="M326 202V240" />
-                    <path class="qc-swap" d="M314 190L338 214M338 190L314 214M314 228L338 252M338 228L314 252" />
-                  </g>
-                  <g class="qc-readout">
-                    <path class="qc-axis" d="M98 320H462" />
-                    <rect class="qc-reference" x="98" y="298" width="304" height="14" />
-                    <rect class="qc-accepted" x="98" y="274" width="268" height="14" />
+                    <path class="qc-link" d="M314 162V206" />
+                    <path class="qc-swap" d="M301 149L327 175M327 149L301 175M301 193L327 219M327 193L301 219" />
+                    <path class="qc-link" d="M366 206V250" />
+                    <path class="qc-swap" d="M353 193L379 219M379 193L353 219M353 237L379 263M379 237L353 263" />
                   </g>
                 </g>
               </svg>`;
@@ -2149,6 +2160,12 @@ function qubitRoutingSummaryTable(full) {
         formatMetric(full.metrics.candidate_added_cnot, { maximumFractionDigits: 0 }),
         `${formatMetric(full.metrics.added_cnot_reduction_vs_lightsabre, { maximumFractionDigits: 0 })} fewer`,
       ],
+      [
+        "Case outcome",
+        "reference",
+        `${formatMetric(full.metrics.wins_vs_lightsabre, { maximumFractionDigits: 0 })} / ${formatMetric(full.metrics.ties_vs_lightsabre, { maximumFractionDigits: 0 })} / ${formatMetric(full.metrics.losses_vs_lightsabre, { maximumFractionDigits: 0 })}`,
+        "wins / ties / losses",
+      ],
     ],
   });
 }
@@ -2215,23 +2232,31 @@ ${body}
 function qubitRoutingReadoutFigure(full, replay) {
   const preview = Array.isArray(replay?.trace?.case_preview) ? replay.trace.case_preview.slice(0, 5) : [];
   const cases = preview.map((item, index) => {
-    const y = 100 + index * 24;
+    const y = 116 + index * 26;
+    const light = item.lightsabre_added_cnot ?? 0;
+    const delta = item.delta_vs_lightsabre ?? 0;
+    const reduction = light > 0 ? (delta / light) * 100 : 0;
     return `<g>
-              <text class="qubit-routing-note" x="72" y="${y}">${escapeHtml(item.id)}</text>
-              <text class="qubit-routing-value" x="354" y="${y}" text-anchor="end">${formatMetric(item.candidate_added_cnot, { maximumFractionDigits: 0 })}</text>
-              <text class="qubit-routing-value" x="488" y="${y}" text-anchor="end">-${formatMetric(item.delta_vs_lightsabre, { maximumFractionDigits: 0 })}</text>
+              <text class="qubit-routing-note" x="52" y="${y}">${escapeHtml(item.id)}</text>
+              <text class="qubit-routing-value" x="278" y="${y}" text-anchor="end">${formatMetric(item.candidate_added_cnot, { maximumFractionDigits: 0 })}</text>
+              <text class="qubit-routing-value" x="386" y="${y}" text-anchor="end">${formatMetric(light, { maximumFractionDigits: 0 })}</text>
+              <text class="qubit-routing-value" x="458" y="${y}" text-anchor="end">${formatMetric(delta, { maximumFractionDigits: 0 })}</text>
+              <text class="qubit-routing-value" x="520" y="${y}" text-anchor="end">${formatMetric(reduction, { maximumFractionDigits: 2, minimumFractionDigits: 2 })}%</text>
             </g>`;
   }).join("\n");
   return paperInlineFigure({
     number: 6,
-    caption: "Accepted replay sample. These rows are a case-level diagnostic, not a second aggregate readout.",
+    caption: "Selected largest case-level savings from the replay export. The rows are sorted by absolute CNOT reduction versus LightSABRE; the final column gives the same reduction as a percentage of the LightSABRE case.",
     className: "qubit-routing-inline-figure qubit-routing-readout-figure",
-    svg: `          <svg class="result-primer-svg qubit-routing-paper-svg" viewBox="0 0 560 232" role="img" aria-label="Case-level replay sample for accepted qubit routing candidate.">
-            <text class="result-axis-label result-figure-title" x="72" y="34">Case-level replay sample</text>
-            <path class="qubit-routing-divider" d="M72 72H488" />
-            <text class="qubit-routing-note" x="72" y="84">sample case</text>
-            <text class="qubit-routing-note" x="354" y="84" text-anchor="end">accepted</text>
-            <text class="qubit-routing-note" x="488" y="84" text-anchor="end">vs LightSABRE</text>
+    svg: `          <svg class="result-primer-svg qubit-routing-paper-svg" viewBox="0 0 560 260" role="img" aria-label="Selected case-level replay examples comparing accepted routing with LightSABRE.">
+            <text class="result-axis-label result-figure-title" x="52" y="34">Selected largest case savings</text>
+            <path class="qubit-routing-divider" d="M52 72H520" />
+            <text class="qubit-routing-note" x="52" y="86">sample case</text>
+            <text class="qubit-routing-note" x="278" y="86" text-anchor="end">accepted</text>
+            <text class="qubit-routing-note" x="386" y="86" text-anchor="end">LightSABRE</text>
+            <text class="qubit-routing-note" x="458" y="86" text-anchor="end">saved</text>
+            <text class="qubit-routing-note" x="520" y="86" text-anchor="end">%</text>
+            <path class="qubit-routing-divider qubit-routing-divider--soft" d="M52 98H520" />
 ${cases}
           </svg>`,
   });


### PR DESCRIPTION
## Summary
- polish the qubit routing result card visual and replace replay validity with Q20 CNOT reduction
- improve the qubit result narrative, case-level savings table, and reproducibility wording
- keep the qubit result generator helpers aligned with the published static page

## Validation
- node --check tools/sync-results.mjs
- git diff --check
- verified /results/qubit-routing-lightsabre/ locally in the in-app browser
