### PR TITLE
docs(results): link qubit source bundle

### DIFF
--- a/results/qubit-routing-lightsabre/index.html
+++ b/results/qubit-routing-lightsabre/index.html
@@ -806,7 +806,7 @@ J(p) = -\Delta_{\mathrm{wCNOT}}(p),
 <p>The public bundle includes the accepted Rust candidate, the evaluation contract, metrics, a curated evolution chain, replay confirmation, public figures, and a curated animated replay at <a href="./run/">the run page</a>. The replay excludes prompts, raw telemetry, local logs, private paths, and operational run state.</p>
 <p>Replaying the result should use the same 24-circuit LightSABRE portfolio, the same Q20, Willow, and Heron-FEZ coupling graphs, the same added-CNOT objective, the same case weights, and the same lower-is-better governed score. Changing the topology set, case set, routing objective, or LightSABRE reference creates a new evaluation, not a replay of this result.</p>
 <p>Under that replay contract, the accepted Rust candidate reproduces 295,782 aggregate added CNOTs, 12,294 fewer than the LightSABRE reference, with a 31 / 6 / 35 win/tie/loss case split.</p>
-<p>The source bundle is available in <a href="https://github.com/Gother-Labs/gother-labs-results/tree/main/results" target="_blank" rel="noreferrer">Göther Labs results repository</a>.</p>
+<p>The source bundle is available in <a href="https://github.com/Gother-Labs/gother-labs-results/tree/main/results/qubit-routing-lightsabre" target="_blank" rel="noreferrer">Göther Labs results repository</a>.</p>
           </article>
         </section>
       </main>


### PR DESCRIPTION
## Why

The Qubit routing result page linked to the generic `gother-labs-results/results` directory even though the dedicated `qubit-routing-lightsabre` public bundle now exists. Readers should land directly on the exact source bundle referenced by the reproducibility section.

Closes #61.

## What changed

- Updated the final source-bundle link on the Qubit routing result page to point directly to `results/qubit-routing-lightsabre` in `gother-labs-results`.

## Why this approach

This is the smallest complete fix: the published page keeps the same copy and link label while making the target precise and reproducible.

## How to review

- Open `results/qubit-routing-lightsabre/index.html`.
- Check the final `Göther Labs results repository` link in the Reproducibility section.

## Validation

- `git diff --check`
- Parsed the page with Python's `HTMLParser` and asserted the direct GitHub URL is present.

## Testing

No runtime code changed. This is a documentation/link correctness fix.
